### PR TITLE
Updates for Podd 1.7 rc2

### DIFF
--- a/MPDModule.cxx
+++ b/MPDModule.cxx
@@ -62,7 +62,7 @@ namespace Decoder {
   }
 
   
-  Int_t MPDModule::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t len) {
+  UInt_t MPDModule::LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len) {
       const UInt_t *p = &evbuffer[pos];
       //UInt_t data;
       fWordsSeen = 0;
@@ -78,10 +78,10 @@ namespace Decoder {
       UInt_t data_count = 0;
 
       //  v5 decoder (with SSP online zero suppression)
-      int ii,jj,kk,ll,mm; // loop indices: ii (event), jj(word), kk(mpd), mm (block)
-      int thesewords;
+      UInt_t ii,jj,kk,mm; // loop indices: ii (event), jj(word), kk(mpd), mm (block)
+      UInt_t thesewords;
       UInt_t hit[3] = {0};
-      int sample_dat[6] = {0}; // loadData in PODD/Analyzer uses int
+      UInt_t sample_dat[6] = {0U};
 
       jj =  0;
       while( jj < len ){
@@ -102,7 +102,7 @@ namespace Decoder {
           return -1;
         }
 
-        int nevent = (thesewords&0xFF);
+        UInt_t nevent = (thesewords&0xFF);
         // Ensure we have enough data
         // (need at least 4 per event: 1 event header + 2 trigger words +
         // 1 event trailer
@@ -478,10 +478,10 @@ namespace Decoder {
       return fWordsSeen;
   }
   
-  Int_t MPDModule::GetData(Int_t adc, Int_t sample, Int_t chan) const {
+  UInt_t MPDModule::GetData( UInt_t adc, UInt_t sample, UInt_t chan) const {
     printf("MPD GET DATA\n");
-    Int_t idx = asc2i(adc, sample, chan);
-    if ((idx < 0 ) || (idx >= fNumChan*fNumSample*fNumADC)) { return 0; }
+    UInt_t idx = asc2i(adc, sample, chan);
+    if (idx >= fNumChan*fNumSample*fNumADC) { return 0; }
     return fData[idx];
   }
   

--- a/MPDModule.h
+++ b/MPDModule.h
@@ -42,10 +42,10 @@ namespace Decoder {
 
     /*
     using Module::GetData;
-    using Module::LoadSlot;
     */
+    using Module::LoadSlot;
 
-    virtual Int_t GetData(Int_t adc, Int_t sample, Int_t chan) const;
+    virtual UInt_t GetData( UInt_t adc, UInt_t sample, UInt_t chan) const;
     virtual void Init();
     virtual void Clear(const Option_t *opt);
     virtual Int_t Decode(const UInt_t *p); // { return 0; };
@@ -75,7 +75,7 @@ namespace Decoder {
     
 //#ifdef LIKEV792x
     // Loads slot data.  if you don't define this, the base class's method is used
-    virtual Int_t LoadSlot(THaSlotData *sldat,  const UInt_t *evbuffer, Int_t pos, Int_t len);
+    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, UInt_t pos, UInt_t len);
 //#endif
 
   private:
@@ -109,7 +109,7 @@ namespace Decoder {
       return adc*fNumSample + sample;
     };
 
-    inline Int_t asc2i(Int_t adc, Int_t sample, Int_t chan) const {
+    inline UInt_t asc2i(UInt_t adc, UInt_t sample, UInt_t chan) const {
       return adc*fNumSample*fNumChan + sample*fNumChan + chan;
     };
     

--- a/SBSBBShower.cxx
+++ b/SBSBBShower.cxx
@@ -157,17 +157,17 @@ Int_t SBSBBShower::ReadDatabase( const TDatime& date )
     }
     if( !err ) {
       // Set up the new channel map
-      Int_t nmodules = fDetMap->GetSize();
+      UInt_t nmodules = fDetMap->GetSize();
       if(fDebug>=2)cout << "Set up the new channel map " << nmodules << endl;
       assert( nmodules > 0 );
       fChanMap.resize(nmodules);
-      for( Int_t i=0, k=0; i < nmodules && !err; i++ ) {
+      for( UInt_t i=0, k=0; i < nmodules && !err; i++ ) {
 	THaDetMap::Module* module = fDetMap->GetModule(i);
-	Int_t nchan = module->hi - module->lo + 1;
+	UInt_t nchan = module->hi - module->lo + 1;
         if(fDebug>=2)cout << " nchan = " << nchan << endl;
 	if( nchan > 0 ) {
 	  fChanMap.at(i).resize(nchan);
-	  for( Int_t j=0; j<nchan; ++j ) {
+	  for( UInt_t j=0; j<nchan; ++j ) {
 	    if(fDebug>=2)cout << " k = " << k << " " << nchan*nmodules << endl;
 	    assert( k < nmodules*nchan );
 	    fChanMap.at(i).at(j) = chanmap.empty() ? k : chanmap[k]-1;
@@ -528,15 +528,15 @@ Int_t SBSBBShower::Decode( const THaEvData& evdata )
   const char* const here = "Decode";
   // Loop over all modules defined for shower detector
   bool has_warning = false;
-  Int_t nmodules = fDetMap->GetSize();
-  for( Int_t i = 0; i < nmodules; i++ ) {
+  UInt_t nmodules = fDetMap->GetSize();
+  for( UInt_t i = 0; i < nmodules; i++ ) {
     THaDetMap::Module* d = fDetMap->GetModule( i );
 
     // Loop over all channels that have a hit.
-    for( Int_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
-      Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
+    for( UInt_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
+      UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
        if( chan > d->hi || chan < d->lo ) continue;    // Not one of my channels.
-      Int_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
+      UInt_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
       if( nhit > 1 || nhit == 0 ) {
 	OSSTREAM msg;
 	msg << nhit << " hits on " << "ADC channel "
@@ -557,9 +557,9 @@ Int_t SBSBBShower::Decode( const THaEvData& evdata )
 #endif
       }
       // Get the data. If multiple hits on a channel, take the first (ADC)
-      Int_t data = evdata.GetData( d->crate, d->slot, chan, 0 );
+      UInt_t data = evdata.GetData( d->crate, d->slot, chan, 0 );
       
-      Int_t jchan = (d->reverse) ? d->hi - chan : chan-d->lo;
+      UInt_t jchan = (d->reverse) ? d->hi - chan : chan-d->lo;
       //cout << " jchan = " <<  jchan << " " << chan << " " << d->hi << " chanmap = " << fChanMap[i][jchan]<< endl;
        if( jchan<0 || jchan>d->hi ) {
 	Error( Here(here), "Illegal detector channel: %d", jchan );

--- a/SBSCDet.cxx
+++ b/SBSCDet.cxx
@@ -1731,13 +1731,13 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 	// and we need one line (=one module) per reference channel
 	// otherwise only the first will be used
 	Int_t i=0;
-	Int_t data;
-	while ((i < fDetMap->GetSize())&&(  i < GetNRefCh() )) {
+	UInt_t data;
+  while( (i < (Int_t)fDetMap->GetSize()) && (i < GetNRefCh()) ) {
 		THaDetMap::Module * d = fDetMap->GetModule(i);
 
 		// Get number of channels with hits
-		Int_t chan=d->lo;
-		Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+		UInt_t chan=d->lo;
+		UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
 #if DEBUG_THIS
 		cout << "Found " << nHits << "  hits in the reference channel for " << GetName()
@@ -1779,7 +1779,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 				Warning(Here(here),"%s",s.str().c_str());
 			}
 #endif//#if DEBUG_LEVEL>=2
-			data = 2^31 ;//new error value to 
+			data = 2^31 ;//new error value to
 			return (0);//Jin Huang
 		} else {
 			if (nHits>1) {
@@ -1823,7 +1823,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 	// two ways to process the data -- one is good for densely packed data in only
 	// one module, the second better for more scattered out data
 
-	while (i < fDetMap->GetSize()){
+	while (i < (Int_t)fDetMap->GetSize()){
 		THaDetMap::Module * d = fDetMap->GetModule(i);
 		Bool_t isAdc=fDetMap->IsADC(d);
 
@@ -1848,7 +1848,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 			if (chan < d->lo || chan > d->hi) 
 				continue; //Not part of this detector
 #else         /* Better for sparse cabling */
-		for (Int_t chan=d->lo; chan<=d->hi; chan++) {
+		for (UInt_t chan=d->lo; chan<=d->hi; chan++) {
 #endif
 
 			DEBUG_MASSINFO(Here(here),
@@ -1857,7 +1857,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 			DEBUG_LINE_MASSINFO(evdata.PrintSlotData(d->crate, d->slot));
 
 			// Get number of hits for this channel and loop through hits
-			Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+			UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
 			if (nHits<=0) continue;
 #if DEBUG_THIS
@@ -1878,7 +1878,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 			// PMTNum is kind of artificial, since it comes from the 
 			// way the detector map is read in: so the first GetNbars are 
 			// left TDC channels, the next right TDC channels and so on
-			Int_t PMTNum  = d->first + chan - d->lo;
+			UInt_t PMTNum  = d->first + chan - d->lo;
 
 			// due to numbering, the first channels are timing reference channels,
 			// so remove them
@@ -1935,7 +1935,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 			for (Int_t hit = 0; hit < nHits; hit++) {
 				// Loop through all hits for this channel, and store the
 				// TDC/ADC  data for this hit
-				Int_t data = evdata.GetData(d->crate, d->slot, chan, hit);
+				UInt_t data = evdata.GetData(d->crate, d->slot, chan, hit);
 				if (isAdc) {  // it is an ADC module
 					if (isLeft) {              
 						new( (*fLaHits)[nextLaHit++] )  SBSAdcHit( pmt, data );

--- a/SBSCDet.cxx
+++ b/SBSCDet.cxx
@@ -1779,7 +1779,7 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 				Warning(Here(here),"%s",s.str().c_str());
 			}
 #endif//#if DEBUG_LEVEL>=2
-			data = 2^31 ;//new error value to
+			data = (1LL << 31);//new error value to
 			return (0);//Jin Huang
 		} else {
 			if (nHits>1) {

--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -207,13 +207,13 @@ Int_t SBSCalorimeter::ReadDatabase( const TDatime& date )
     // the numbering of the blocks starts on the top left corner when standing
     // behind the detector and facing the target. We turn this into a row
     // and column, layer as appropriate.
-    Int_t nmodules = GetDetMap()->GetSize();
+    UInt_t nmodules = GetDetMap()->GetSize();
     assert( nmodules > 0 );
     fChanMap.resize(nmodules);
     Bool_t makeADC = true;
-    for( Int_t i = 0, k = 0; i < nmodules && !err; i++) {
+    for( UInt_t i = 0, k = 0; i < nmodules && !err; i++) {
       THaDetMap::Module *d = GetDetMap()->GetModule(i);
-      Int_t nchan = d->GetNchan();
+      UInt_t nchan = d->GetNchan();
       if( nchan > 0 ) {
         fChanMap[i].resize(nchan);
         // To simplify finding out which channels are ADCs and which are TDCs
@@ -224,7 +224,7 @@ Int_t SBSCalorimeter::ReadDatabase( const TDatime& date )
         } else {
           d->MakeTDC();
         }
-        for(Int_t chan = 0; chan < nchan; chan++) {
+        for(UInt_t chan = 0; chan < nchan; chan++) {
           assert( k < fNelem );
           fChanMap[i][chan] = chanmap.empty() ? k : chanmap[k] - fChanMapStart;
           k++;
@@ -440,15 +440,15 @@ Int_t SBSCalorimeter::Decode( const THaEvData& evdata )
 
   SBSCalorimeterBlock *blk = 0;
   // Loop over all modules in the calorimeter and decode accordingly
-  for( UShort_t imod = 0; imod < fDetMap->GetSize(); imod++ ) {
+  for( UInt_t imod = 0; imod < fDetMap->GetSize(); imod++ ) {
     THaDetMap::Module *d = fDetMap->GetModule( imod );
 
-    for(Int_t ihit = 0; ihit < evdata.GetNumChan( d->crate, d->slot ); ihit++) {
+    for(UInt_t ihit = 0; ihit < evdata.GetNumChan( d->crate, d->slot ); ihit++) {
       fNhits++;
 
       // Get the next available channel, skipping the ones that do not belong
       // to our detector
-      Int_t chan = evdata.GetNextChan( d->crate, d->slot, ihit );
+      UInt_t chan = evdata.GetNextChan( d->crate, d->slot, ihit );
       if( chan > d->hi || chan < d->lo ) continue;
 
       // Get the block index for this crate,slot,channel combo
@@ -467,7 +467,7 @@ Int_t SBSCalorimeter::Decode( const THaEvData& evdata )
 Int_t SBSCalorimeter::DecodeADC( const THaEvData& evdata,
     SBSCalorimeterBlock *blk, THaDetMap::Module *d, Int_t chan)
 {
-  Int_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
+  UInt_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
   //std::cout << d->crate << " " << d->slot << " " << chan << std::endl;
   if(nhit <= 0 )
     return 0;
@@ -499,7 +499,7 @@ Int_t SBSCalorimeter::DecodeTDC( const THaEvData& evdata,
 
   // TODO: Again, no clue what to do for multiple hits
   // For now, just take the first one
-  Int_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
+  UInt_t nhit = evdata.GetNumHits(d->crate, d->slot, chan);
   if(nhit > 0 ) {
     blk->TDC()->Process( evdata.GetData(d->crate, d->slot, chan, 0) );
   }

--- a/SBSDecodeF1TDCModule.cxx
+++ b/SBSDecodeF1TDCModule.cxx
@@ -97,7 +97,7 @@ void SBSDecodeF1TDCModule::Clear(const Option_t* opt) {
   for(Int_t i=0; i<fNumHits.size(); i++) fNumHits[i]=0;
 }
 
-Int_t SBSDecodeF1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len) {
+UInt_t SBSDecodeF1TDCModule::LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, UInt_t pos, UInt_t len) {
 // the 4-arg version of LoadSlot.  Let it call the 3-arg version.
 // I'm not sure we need both (historical)
 
@@ -105,7 +105,7 @@ Int_t SBSDecodeF1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
 
   }
 
-Int_t SBSDecodeF1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop) {
+UInt_t SBSDecodeF1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop) {
 // This is the 3-arg version of LoadSlot
 // Note, this increments evbuffer
   if (fDebugFile) *fDebugFile << "SBSDecodeF1TDCModule:: loadslot "<<endl;

--- a/SBSDecodeF1TDCModule.h
+++ b/SBSDecodeF1TDCModule.h
@@ -45,9 +45,9 @@ public:
    Int_t GetNumSlots() const { return nF1; };
 
    // Loads slot data for bank structures
-   virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len);
+   virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, UInt_t pos, UInt_t len);
 // Loads sldat and increments ptr to evbuffer
-   Int_t LoadSlot(THaSlotData *sldat,  const UInt_t* evbuffer, const UInt_t *pstop );
+   UInt_t LoadSlot(THaSlotData *sldat,  const UInt_t* evbuffer, const UInt_t *pstop );
 
 private:
 

--- a/SBSECal.cxx
+++ b/SBSECal.cxx
@@ -89,10 +89,10 @@ Int_t SBSECal::ReadDatabase( const TDatime& date )
     fNclublk = nclbl;
 
     // Clear out the old detector map before reading a new one
-    UShort_t mapsize = fDetMap->GetSize();
+    UInt_t mapsize = fDetMap->GetSize();
     delete [] fNChan;
     if( fChanMap ) {
-        for( UShort_t i = 0; i<mapsize; i++ )
+        for( UInt_t i = 0; i<mapsize; i++ )
             delete [] fChanMap[i];
     }
     delete [] fChanMap;
@@ -122,7 +122,7 @@ Int_t SBSECal::ReadDatabase( const TDatime& date )
 
     fNChan = new UShort_t[ mapsize ];
     fChanMap = new UShort_t*[ mapsize ];
-    for( UShort_t i=0; i < mapsize; i++ ) {
+    for( UInt_t i=0; i < mapsize; i++ ) {
         THaDetMap::Module* module = fDetMap->GetModule(i);
         fNChan[i] = module->hi - module->lo + 1;
         if( fNChan[i] > 0 )
@@ -130,7 +130,7 @@ Int_t SBSECal::ReadDatabase( const TDatime& date )
         else {
             Error( Here(here), "No channels defined for module %d.", i);
             delete [] fNChan; fNChan = NULL;
-            for( UShort_t j=0; j<i; j++ )
+            for( UInt_t j=0; j<i; j++ )
                 delete [] fChanMap[j];
             delete [] fChanMap; fChanMap = NULL;
             fclose(fi);
@@ -139,8 +139,8 @@ Int_t SBSECal::ReadDatabase( const TDatime& date )
     }
     // Read channel map
     fgets ( buf, LEN, fi );
-    for ( UShort_t i = 0; i < mapsize; i++ ) {
-        for ( UShort_t j = 0; j < fNChan[i]; j++ ) 
+    for ( UInt_t i = 0; i < mapsize; i++ ) {
+        for ( UInt_t j = 0; j < fNChan[i]; j++ )
             fscanf (fi, "%hu", *(fChanMap+i)+j ); 
         fgets ( buf, LEN, fi );
     }
@@ -403,17 +403,17 @@ Int_t SBSECal::Decode( const THaEvData& evdata )
     ClearEvent();
 
     // Loop over all modules defined for shower detector
-    for( UShort_t i = 0; i < fDetMap->GetSize(); i++ ) {
+    for( UInt_t i = 0; i < fDetMap->GetSize(); i++ ) {
         THaDetMap::Module* d = fDetMap->GetModule( i );
 
         // Loop over all channels that have a hit.
-        for( Int_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
+        for( UInt_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
 
-            Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
+            UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
             if( chan > d->hi || chan < d->lo ) continue;    // Not one of my channels.
 
             // Get the data. shower blocks are assumed to have only single hit (hit=0)
-            Int_t data = evdata.GetData( d->crate, d->slot, chan, 0 );
+            UInt_t data = evdata.GetData( d->crate, d->slot, chan, 0 );
 
             // Copy the data to the local variables.
             Int_t k = *(*(fChanMap+i)+(chan-d->lo)) - 1;

--- a/SBSGEMPlane.cxx
+++ b/SBSGEMPlane.cxx
@@ -251,25 +251,23 @@ void    SBSGEMPlane::Clear( Option_t* opt){
 
 Int_t   SBSGEMPlane::Decode( const THaEvData& evdata ){
   //std::cout << "[SBSGEMPlane::Decode " << fName << "]" << std::endl;
-    int i;
-    
     //#ifdef MCDATA
     if(fIsMC){
-      Int_t nmodules = fDetMap->GetSize();
+      UInt_t nmodules = fDetMap->GetSize();
       //std::cout << "nmodules " << nmodules << std::endl;
       int strip0 = 0;
       for( Int_t i = 0; i < nmodules; i++ ) {
 	THaDetMap::Module* d = fDetMap->GetModule( i );
 	//if(evdata.GetNumChan( d->crate, d->slot )>0)std::cout << fName << " " << d->crate << " " << d->slot << " " << evdata.GetNumChan( d->crate, d->slot ) << std::endl;
-	for( Int_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
+	for( UInt_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
 	
-	  Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
+    UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
 	  //std::cout << j << " chan " << chan << " first " << d->first << " lo " << d->lo << " hi " << d->hi << std::endl;
 	  if( chan > d->hi || chan < d->lo ) continue;    // Not one of my channels.
 	  int strip = strip0 + chan-d->lo;
 	  assert(strip<fNch);
 	
-	  Int_t nsamps = evdata.GetNumHits(d->crate, d->slot, chan);
+	  UInt_t nsamps = evdata.GetNumHits(d->crate, d->slot, chan);
 	  if(nsamps!=N_MPD_TIME_SAMP)continue;
 	  //std::cout << nsamps << std::endl;
 	  
@@ -299,26 +297,26 @@ Int_t   SBSGEMPlane::Decode( const THaEvData& evdata ){
         Int_t effChan = it->mpd_id << 8 | it->adc_id;
         // Find channel for this crate/slot
 
-        Int_t nchan = evdata.GetNumChan( it->crate, it->slot );
+        UInt_t nchan = evdata.GetNumChan( it->crate, it->slot );
 
 	//        printf("nchan = %d\n", nchan );
 	//if(nchan)std::cout << GetName() << " " << it->crate << " " << it->slot << " " << nchan << std::endl;
 	  
 	
-        for( Int_t ichan = 0; ichan < nchan; ++ichan ) {
-	  Int_t chan = evdata.GetNextChan( it->crate, it->slot, ichan );
-	  if( chan != effChan ) continue; // not part of this detector
+        for( UInt_t ichan = 0; ichan < nchan; ++ichan ) {
+          UInt_t chan = evdata.GetNextChan( it->crate, it->slot, ichan );
+          if( chan != effChan ) continue; // not part of this detector
 
 
-	  Int_t nsamp = evdata.GetNumHits( it->crate, it->slot, chan );
-	  assert(nsamp%N_MPD_TIME_SAMP==0);
-	  Int_t nstrips = nsamp/N_MPD_TIME_SAMP;
+          UInt_t nsamp = evdata.GetNumHits( it->crate, it->slot, chan );
+          assert(nsamp%N_MPD_TIME_SAMP==0);
+          UInt_t nstrips = nsamp/N_MPD_TIME_SAMP;
 
 	  // Loop over all the strips and samples in the data
 	  Int_t isamp = 0;
-	  for( Int_t istrip = 0; istrip < nstrips; ++istrip ) {
+	  for( UInt_t istrip = 0; istrip < nstrips; ++istrip ) {
 	    assert(isamp<nsamp);
-	    Int_t strip = evdata.GetRawData(it->crate, it->slot, chan, isamp);
+      UInt_t strip = evdata.GetRawData(it->crate, it->slot, chan, isamp);
 	    assert(strip>=0&&strip<128);
 	    // Madness....   copy pasted from stand alone decoder
 	    // I bet there's a more elegant way to express this
@@ -334,7 +332,7 @@ Int_t   SBSGEMPlane::Decode( const THaEvData& evdata ){
 	    fStrip[strip] = strip;
 	    fNchEff++;
 	    fStrip_.push_back(strip);
-	    for(Int_t adc_samp = 0; adc_samp < N_MPD_TIME_SAMP; adc_samp++) {
+	    for(UInt_t adc_samp = 0; adc_samp < N_MPD_TIME_SAMP; adc_samp++) {
 	      fadc[adc_samp][strip] =  evdata.GetData(it->crate, it->slot,
 						     chan, isamp++) - fPedestal[strip];
 

--- a/SBSGRINCH.cxx
+++ b/SBSGRINCH.cxx
@@ -341,14 +341,14 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
   Int_t channel;
   ushort tdctime_raw;
   bool col0_ismaxsize = false;
-  
-  if(fabs((-fPMTmatrixHext/2.0-fY_TCPMT)/fY_TCPMT)<1.0e-4)col0_ismaxsize = true;
-  bool col_ismaxsize;
+
+  if( fabs((-fPMTmatrixHext / 2.0 - fY_TCPMT) / fY_TCPMT) < 1.0e-4 )
+    col0_ismaxsize = true;
 
   //int gchannel;
   int row, col;
   double X, Y;
-  double TDC_r, TDC_f;
+  double TDC_r = kBig, TDC_f = kBig;
   double ADC;
   
   if(fDebug)cout << fDetMap->GetSize() << endl;
@@ -360,12 +360,8 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
 	   << " num chans " << evdata.GetNumChan(d->crate, d->slot) << endl;
     
     for( Int_t j = 0; j < evdata.GetNumChan( d->crate, d->slot ); j++) {
-      if(col0_ismaxsize){
-	col_ismaxsize = true;
-      }else{
-	col_ismaxsize = false;
-      }
-      
+      bool col_ismaxsize = col0_ismaxsize;
+
       UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
       
       if( chan > d->hi || chan < d->lo ) continue; // Not one of my channels

--- a/SBSGRINCH.cxx
+++ b/SBSGRINCH.cxx
@@ -26,15 +26,7 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
-#if defined(HAS_SSTREAM) || (defined(__GNUC__)&&(__GNUC__ >= 3))
 #include <sstream>
-#define HAS_SSTREAM
-#define ISTR istringstream
-#else
-#include <strstream>
-#undef HAS_SSTREAM
-#define ISTR istrstream
-#endif
 #include "THaBenchmark.h"
 
 using namespace std;
@@ -346,7 +338,7 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
   SBSGRINCH_Hit* theHit;
   
   bool edge;
-  short channel;
+  Int_t channel;
   ushort tdctime_raw;
   bool col0_ismaxsize = false;
   
@@ -360,7 +352,7 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
   double ADC;
   
   if(fDebug)cout << fDetMap->GetSize() << endl;
-  for( UShort_t i = 0; i < fDetMap->GetSize(); i++ ) {
+  for( UInt_t i = 0; i < fDetMap->GetSize(); i++ ) {
     THaDetMap::Module* d = fDetMap->GetModule( i );
     
     if(fDebug)
@@ -374,12 +366,12 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
 	col_ismaxsize = false;
       }
       
-      Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
+      UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
       
       if( chan > d->hi || chan < d->lo ) continue; // Not one of my channels
       
       // Get the data.
-      Int_t nhit = evdata.GetNumHits( d->crate, d->slot, chan );
+      UInt_t nhit = evdata.GetNumHits( d->crate, d->slot, chan );
       
       if( GetNumHits()+nhit > fMaxNumHits ) {
 	Warning("Decode", "Too many hits! Should never ever happen! "
@@ -393,7 +385,7 @@ Int_t SBSGRINCH::Decode( const THaEvData& evdata )
       if(fDebug)
 	cout << "chan " << chan << " nhits = " << nhit << endl;
       
-      for (int hit = 0; hit < nhit; hit++) {
+      for (UInt_t hit = 0; hit < nhit; hit++) {
 	
 	// Fill hit array
 	// UInt_t data = evdata.GetData(d->crate,d->slot,chan,hit);

--- a/SBSGRINCH_ClusterList.h
+++ b/SBSGRINCH_ClusterList.h
@@ -29,8 +29,8 @@ class SBSGRINCH_Hit : public TObject {
  SBSGRINCH_Hit( Int_t pmtnum, Int_t TDC_r, Int_t TDC_f, Int_t ADC, Int_t i, Int_t j, 
 		Float_t x, Float_t y ) :
   fPMTNum(pmtnum), fTDC_r(TDC_r), fTDC_f(TDC_f), fADC(ADC), 
-    fRow(i), fCol(j), fX(x), fY(y), fFlag(0), 
-    tdcr_set(false), tdcf_set(false), fVeto(0) {}
+    fRow(i), fCol(j), fX(x), fY(y), fFlag(0),
+    fVeto(0), tdcr_set(false), tdcf_set(false) {}
   virtual ~SBSGRINCH_Hit() {}
   
   void       Show(FILE * fout1);

--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -67,7 +67,7 @@ Int_t SBSHCal::Decode( const THaEvData& evdata )
 {
   Int_t err = SBSCalorimeter::Decode(evdata);
   if(fWithLED) {
-    Int_t ihit = evdata.GetNumChan(fLEDCrate,fLEDSlot);
+    UInt_t ihit = evdata.GetNumChan(fLEDCrate,fLEDSlot);
     if(ihit!=2 ) {
       //std::cerr << "ihit=" << ihit << std::endl;
       return 0;

--- a/SBSScintPlane.cxx
+++ b/SBSScintPlane.cxx
@@ -1647,7 +1647,7 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
                 Warning(Here(here),"%s",s.str().c_str());
             }
 #endif//#if DEBUG_LEVEL>=3
-            data = 2^31 ;//new error value to 
+            data = (1LL << 31);//new error value to
             return (0);//Jin Huang
         } else {
             if (nHits>1) {

--- a/SBSScintPlane.cxx
+++ b/SBSScintPlane.cxx
@@ -1605,13 +1605,13 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
     // and we need one line (=one module) per reference channel
     // otherwise only the first will be used
     Int_t i=0;
-    Int_t data;
-    while ((i < fDetMap->GetSize())&&(  i < GetNRefCh() )) {
+    UInt_t data;
+    while ((i < (Int_t)fDetMap->GetSize())&&(  i < GetNRefCh() )) {
         THaDetMap::Module * d = fDetMap->GetModule(i);
 
         // Get number of channels with hits
-        Int_t chan=d->lo;
-        Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+        UInt_t chan=d->lo;
+        UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
         //complaining about error reference channel
         if (nHits!=1) 
@@ -1717,7 +1717,7 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
             if (chan < d->lo || chan > d->hi) 
                 continue; //Not part of this detector
 #else         /* Better for sparse cabling */
-        for (Int_t chan=d->lo; chan<=d->hi; chan++) {
+        for (UInt_t chan=d->lo; chan<=d->hi; chan++) {
 #endif
 
             DEBUG_MASSINFO(Here(here),
@@ -1726,7 +1726,7 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
             DEBUG_LINE_MASSINFO(evdata.PrintSlotData(d->crate, d->slot));
 
             // Get number of hits for this channel and loop through hits
-            Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+            UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
             if (nHits<=0) continue;
 #if DEBUG_THIS
@@ -1801,10 +1801,10 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
 #endif
 
             // loop through the hits
-            for (Int_t hit = 0; hit < nHits; hit++) {
+            for (UInt_t hit = 0; hit < nHits; hit++) {
                 // Loop through all hits for this channel, and store the
                 // TDC/ADC  data for this hit
-                Int_t data = evdata.GetData(d->crate, d->slot, chan, hit);
+                UInt_t data = evdata.GetData(d->crate, d->slot, chan, hit);
                 if (isAdc) {  // it is an ADC module
                     if (isLeft) {              
                         new( (*fLaHits)[nextLaHit++] )  SBSAdcHit( pmt, data );

--- a/SBSSimADC.cxx
+++ b/SBSSimADC.cxx
@@ -89,7 +89,7 @@ namespace Decoder {
   void SBSSimADC::CheckDecoderStatus() const {
   }
 
-  Int_t SBSSimADC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
+UInt_t SBSSimADC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
       const UInt_t *pstop) {
     Clear();
     unsigned int nwords = 0;
@@ -143,8 +143,8 @@ namespace Decoder {
    return 0;
   }
 
-  Int_t SBSSimADC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
-      Int_t pos, Int_t len) {
+  UInt_t SBSSimADC::LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer,
+                              UInt_t pos, UInt_t len) {
     return LoadSlot(sldat,evbuffer+pos,evbuffer+pos+len);
     //return SBSSimADC::LoadSlot(sldat,evbuffer,len);
   }

--- a/SBSSimADC.h
+++ b/SBSSimADC.h
@@ -33,13 +33,13 @@ namespace Decoder {
     virtual void Init();
     virtual void CheckDecoderStatus() const;
     virtual void ClearDataVectors();
-    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop);
-    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t len);
+    virtual UInt_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop);
+    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
 
     // We don't need these functions for simulated data, but must be defined
     // so that this won't be an abstract class
-    Int_t LoadNextEvBuffer(THaSlotData*) {return 0;};// needs return something for compilation
-    Int_t LoadThisBlock(THaSlotData*, std::vector<UInt_t >) {return 0;};// needs return something for compilation
+    UInt_t LoadNextEvBuffer(THaSlotData*) {return 0;};// needs return something for compilation
+    UInt_t LoadThisBlock(THaSlotData*, std::vector<UInt_t >) {return 0;};// needs return something for compilation
     Int_t Decode(const UInt_t *) { return 0; }; // use DecodeOneWord instead
 
     /*

--- a/SBSSimTDC.cxx
+++ b/SBSSimTDC.cxx
@@ -88,7 +88,7 @@ namespace Decoder {
   void SBSSimTDC::CheckDecoderStatus() const {
   }
 
-  Int_t SBSSimTDC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
+  UInt_t SBSSimTDC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
       const UInt_t *pstop) {
     Clear();
     unsigned int nwords = 0;
@@ -134,8 +134,8 @@ namespace Decoder {
    return 0;
   }
 
-  Int_t SBSSimTDC::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer,
-      Int_t pos, Int_t len) {
+  UInt_t SBSSimTDC::LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer,
+                              UInt_t pos, UInt_t len) {
     return LoadSlot(sldat,evbuffer+pos,evbuffer+pos+len);
     //return SBSSimTDC::LoadSlot(sldat,evbuffer,len);
   }

--- a/SBSSimTDC.h
+++ b/SBSSimTDC.h
@@ -32,13 +32,13 @@ namespace Decoder {
     virtual void Init();
     virtual void CheckDecoderStatus() const;
     virtual void ClearDataVectors();
-    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop);
-    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t len);
+    virtual UInt_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop);
+    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
 
     // We don't need these functions for simulated data, but must be defined
     // so that this won't be an abstract class
-    Int_t LoadNextEvBuffer(THaSlotData*) {return 0;};// needs return something for compilation
-    Int_t LoadThisBlock(THaSlotData*, std::vector<UInt_t >) {return 0;};// needs return something for compilation
+    UInt_t LoadNextEvBuffer(THaSlotData*) {return 0;};// needs return something for compilation
+    UInt_t LoadThisBlock(THaSlotData*, std::vector<UInt_t >) {return 0;};// needs return something for compilation
     Int_t Decode(const UInt_t *) { return 0; }; // use DecodeOneWord instead
 
 

--- a/SBSTimingHodoscope.cxx
+++ b/SBSTimingHodoscope.cxx
@@ -2064,7 +2064,7 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 				Warning(Here(here),"%s",s.str().c_str());
 			}
 #endif//#if DEBUG_LEVEL>=2
-			data = 2^31 ;//new error value to 
+			data = (1LL << 31);//new error value to
 			return (0);//Jin Huang
 		} else {
 			if (nHits>1) {

--- a/SBSTimingHodoscope.cxx
+++ b/SBSTimingHodoscope.cxx
@@ -327,7 +327,7 @@ Int_t SBSTimingHodoscope::ReadDatabase(const TDatime& date)
   // Step through the modules already filled and find out how many reference
   // channels we have (and also, make these modules TDCs)
   nref_chans = 0;
-  for( UShort_t imod = 0; imod < fDetMap->GetSize(); imod++ ) {
+  for( UInt_t imod = 0; imod < fDetMap->GetSize(); imod++ ) {
     THaDetMap::Module *d = fDetMap->GetModule( imod );
     d->MakeTDC();
     if(d->refindex == -1) {
@@ -346,7 +346,7 @@ Int_t SBSTimingHodoscope::ReadDatabase(const TDatime& date)
       new((*fRefCh)[i]) SBSScintPMT(1.0,0,ref_ch_res[i]);
     }
   } else {
-    Error( Here(here), "Malformed ref_ch_res in database. %d entries provided"
+    Error( Here(here), "Malformed ref_ch_res in database. %lu entries provided"
         " but expected either 1 or %d",ref_ch_res.size(),nref_chans);
     return kInitError;
 
@@ -2015,13 +2015,13 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 	// and we need one line (=one module) per reference channel
 	// otherwise only the first will be used
 	Int_t i=0;
-	Int_t data;
-	while ((i < fDetMap->GetSize())&&(  i < GetNRefCh() )) {
+	UInt_t data;
+  while( (i < (Int_t)fDetMap->GetSize()) && (i < GetNRefCh()) ) {
 		THaDetMap::Module * d = fDetMap->GetModule(i);
 
 		// Get number of channels with hits
-		Int_t chan=d->lo;
-		Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+		UInt_t chan=d->lo;
+		UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
 #if DEBUG_THIS
 		cout << "Found " << nHits << "  hits in the reference channel for " << GetName()
@@ -2108,7 +2108,7 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 	// two ways to process the data -- one is good for densely packed data in only
 	// one module, the second better for more scattered out data
 
-	while (i < fDetMap->GetSize()){
+	while (i < (Int_t)fDetMap->GetSize()){
 		THaDetMap::Module * d = fDetMap->GetModule(i);
 		Bool_t isAdc=fDetMap->IsADC(d);
 
@@ -2133,7 +2133,7 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 			if (chan < d->lo || chan > d->hi) 
 				continue; //Not part of this detector
 #else         /* Better for sparse cabling */
-		for (Int_t chan=d->lo; chan<=d->hi; chan++) {
+		for (UInt_t chan=d->lo; chan<=d->hi; chan++) {
 #endif
 
 			DEBUG_MASSINFO(Here(here),
@@ -2142,7 +2142,7 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 			DEBUG_LINE_MASSINFO(evdata.PrintSlotData(d->crate, d->slot));
 
 			// Get number of hits for this channel and loop through hits
-			Int_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
+      UInt_t nHits = evdata.GetNumHits(d->crate, d->slot, chan);
 
 			if (nHits<=0) continue;
 #if DEBUG_THIS
@@ -2217,10 +2217,10 @@ Int_t SBSTimingHodoscope::Decode( const THaEvData& evdata )
 #endif
 
 			// loop through the hits
-			for (Int_t hit = 0; hit < nHits; hit++) {
+			for (UInt_t hit = 0; hit < nHits; hit++) {
 				// Loop through all hits for this channel, and store the
 				// TDC/ADC  data for this hit
-				Int_t data = evdata.GetData(d->crate, d->slot, chan, hit);
+        Int_t data = evdata.GetData(d->crate, d->slot, chan, hit);
 				if (isAdc) {  // it is an ADC module
 					if (isLeft) {              
 						new( (*fLaHits)[nextLaHit++] )  SBSAdcHit( pmt, data );


### PR DESCRIPTION
Adjust the codebase to work with Podd 1.7.0-rc2.

In a few places, Int_t parameters and return values in the decoder API have been changed to UInt_t. I have propagated these changes beyond the API calls to also change the type of some local variables accordingly. Even though it might look invasive, these are essentially trivial changes.

I also took the opportunity to fix a number of compilation warnings about suspicious code. I left "unused variable" warnings alone.

If you merge this pull request, you will also need to update to the latest Podd release on the master branch. The relevant tag is Release-170-rc2.