### PR TITLE
Skbarcus dev

### DIFF
--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -21,6 +21,7 @@ SBSHCal::SBSHCal( const char* name, const char* description,
   SetModeTDC(SBSModeTDC::kTDCSimple);
   SetDisableRefTDC(true);
   fWithLED = true;
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -21,7 +21,6 @@ SBSHCal::SBSHCal( const char* name, const char* description,
   SetModeTDC(SBSModeTDC::kTDCSimple);
   SetDisableRefTDC(true);
   fWithLED = true;
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/SBSHCalLEDModule.cxx
+++ b/SBSHCalLEDModule.cxx
@@ -50,7 +50,7 @@ namespace Decoder {
 		}
 	
 		
-		Int_t HCalLED::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t ) {
+		UInt_t HCalLED::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t ) {
 			const UInt_t *p = &evbuffer[pos];
 			fWordsSeen=0;
 			UInt_t j = 0;

--- a/SBSHCalLEDModule.h
+++ b/SBSHCalLEDModule.h
@@ -48,7 +48,7 @@ namespace Decoder {
     //virtual void Clear(const Option_t *opt);
     virtual Int_t Decode(const UInt_t *p); // { return 0; };
     
-    virtual Int_t LoadSlot(THaSlotData *sldat,  const UInt_t *evbuffer, Int_t pos, Int_t len);
+    virtual UInt_t LoadSlot(THaSlotData *sldat,  const UInt_t *evbuffer, UInt_t pos, UInt_t len);
 //#endif
 
   private:


### PR DESCRIPTION
Changed the SBSHCalLED.cxx and .h files to account for previous analyzer change switching Int_t to UInt_t. This change was made to the return values of the LoadSlot function and the arguments passed to this function. This change will enable the decoding of HCal LED info again.