### PR TITLE
Make cluster matching cuts DB parameters

### DIFF
--- a/SBSBBTotalShower.cxx
+++ b/SBSBBTotalShower.cxx
@@ -235,11 +235,14 @@ Int_t SBSBBTotalShower::ReadDatabase( const TDatime& date )
   DBRequest config_request[] = {
     { "components",   &components_names,   kString, 0, 1},
     { "pssh_matchmap_x",   &pssh_matchmap_x,   kIntV, 0, 1},
+    { "MaxDx",   &fMaxDx,   kFloat, 0, 1},
+    { "MaxDy",   &fMaxDy,   kFloat, 0, 1},
     { "pssh_matchmap_y",   &pssh_matchmap_y,   kIntV, 0, 1},
     { 0 }
   };
   
   Int_t err = LoadDB( file, date, config_request, fPrefix );
+
 
   if( err ) {
     return kInitError;
@@ -299,7 +302,7 @@ Int_t SBSBBTotalShower::CoarseProcess(TClonesArray& tracks )
 	SBSElement* psblk = fPreShower->GetElement(PreShowerBlockSet[nps].id);
 	     Float_t xps =  PreShowerBlockSet[nps].x;
 	     Float_t yps =  PreShowerBlockSet[nps].y;
-      Bool_t MatchCriterion = abs(xsh-xps) < fMaxDx;
+      Bool_t MatchCriterion = abs(xsh-xps) < fMaxDx && abs(ysh-yps) < fMaxDy;
       if (MatchCriterion) {
 	PreShowerBlockSet[nps].InCluster = kTRUE;
 	if (!AddToPreShowerCluster) {

--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -94,6 +94,7 @@ Int_t SBSCalorimeter::ReadDatabase( const TDatime& date )
     { "nmax_cluster",   &fMaxNclus,   kInt, 0, true }, ///< maximum number of clusters to store
     { "const", &fConst, kFloat, 0, true }, ///< const from gain correction 
     { "slope", &fSlope, kFloat, 0, true }, ///< slope for gain correction 
+    { "Rmax_dis", &fRmax_dis, kFloat, 0, true }, ///< slope for gain correction 
     { "acc_charge", &fAccCharge, kFloat, 0, true }, ///< accumulated charge
     { 0 } ///< Request must end in a NULL
   };


### PR DESCRIPTION
SSBBBTotalShower
Matching between Shower and PreShower
uses cuts on the X and Y position differences between
SHower cluster and Preshower blocks.
The parameters are MaxDx and MaxDy in meters

SBSCalorimeter

Determining blocks to include in the cluster uses a radius
cut between the block and the cluster
The parameter RMax_dis in meters