### PR TITLE
Modify SBSGenericDetector, SBSCalorimeter, SBSData

### DIFF
--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -138,10 +138,12 @@ Int_t SBSCalorimeter::ReadDatabase( const TDatime& date )
         SBSData::Waveform *wave = blk->Waveform();
 	Float_t gain = wave->GetGain();
 	wave->SetGain(gain*trigtoFADCratio[ne]);
+	wave->SetTrigCal(trigtoFADCratio[ne]);
 	}
 	if (WithADC() && fModeADC == SBSModeADC::kADC) {
 	Double_t gain=blk->ADC()->GetGain();
 	blk->ADC()->SetGain(gain*trigtoFADCratio[ne]);
+	blk->ADC()->SetTrigCal(trigtoFADCratio[ne]);
 	}
       }
     } else {

--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -34,7 +34,7 @@ namespace SBSData {
     Float_t IntRaw=  integral*GetChanTomV()*pC_Conv;
     Float_t IntVal=  (IntRaw-PedVal*(GetNSA()+GetNSB()+1)*pC_Conv)*GetGain();
     Float_t AmpRaw=  amp*GetChanTomV();
-    Float_t AmpVal=  (AmpRaw-PedVal)*GetGain();
+    Float_t AmpVal=  (AmpRaw-PedVal)*GetAmpCal();
     SingleData t_integral = { IntRaw, IntVal   };
     SingleData t_time     = { time, TimeVal };
     SingleData t_amp     = { AmpRaw, AmpVal };
@@ -216,7 +216,7 @@ namespace SBSData {
     fSamples.pulse.time.raw = FineTime;
     fSamples.pulse.time.val = (FineTime)*fSamples.tcal;
     fSamples.pulse.amplitude.raw = max;
-    fSamples.pulse.amplitude.val = (max-fSamples.ped)*fSamples.cal;
+    fSamples.pulse.amplitude.val = (max-fSamples.ped)*fSamples.acal;
     if (max==0) fSamples.pulse.amplitude.val=max;
     //
     fHasData = (vals.size() > 0);

--- a/SBSData.h
+++ b/SBSData.h
@@ -28,6 +28,7 @@ namespace SBSData {
     Float_t cal; //< Calibration constant for ADC integral
     Float_t tcal; //< Calibration constant for TDC value
     Float_t acal; //< Calibration constant for ADC amplitude (peak)
+    Float_t trigcal; //< ratio Trig amp to FADC amp
     UInt_t NSB; //< Programmed # of samples before threshold in FADC
     UInt_t NSA; //< Programmed # of samples after threshold in FADC
     Int_t NPedBin; //< Programmed # of samples used in pedestal average in FADC
@@ -47,6 +48,7 @@ namespace SBSData {
     Float_t ChanTomV; //< Conversion of ADC channel to milliVolt.
     Float_t tcal; //< Calibration constant for TDC value
     Float_t acal; //< Calibration constant for ADC amplitude (peak)
+    Float_t trigcal; //< ratio Trig amp to FADC amp
     UInt_t FixThresBin; //<Fixed Threshold Bin when no peak found
     UInt_t NSB; //<Number of bins before Threshold Bin integrate when Threshold Bin found
     UInt_t NSA; //<Number of bins after Threshold Bin integrate when Threshold Bin found
@@ -91,6 +93,7 @@ namespace SBSData {
       Float_t GetTimeCal()                 const { return fADC.tcal; }
       Float_t GetGoodTimeCut()              const { return fADC.GoodTimeCut;}
       Float_t GetAmpCal()                  const { return fADC.acal; }
+      Float_t GetTrigCal()                  const { return fADC.trigcal; }
       UInt_t GetNSA()                      const { return fADC.NSA; }
       UInt_t GetNSB()                      const { return fADC.NSB; }
       Int_t GetNPedBin()                      const { return fADC.NPedBin; }
@@ -116,6 +119,7 @@ namespace SBSData {
       void SetTimeCal(Float_t var) { fADC.tcal = var; }
       void SetGoodTimeCut(Float_t var) { fADC.GoodTimeCut = var; }
       void SetAmpCal(Float_t var) { fADC.acal = var; }
+      void SetTrigCal(Float_t var) { fADC.trigcal = var; }
       void SetGoodHit(Int_t i) { fADC.good_hit = i; }
       void SetChanTomV(Float_t var) { fADC.ChanTomV = var; }
       void SetADCParam(Float_t i1,Int_t i2,Int_t i3, Int_t i4,Float_t i5) { fADC.ChanTomV=i1;fADC.NSB=i2;fADC.NSA=i3;fADC.NPedBin=i4;fADC.GoodTimeCut=i5;}
@@ -195,6 +199,8 @@ namespace SBSData {
       Float_t GetGain() const { return fSamples.cal; }
       Float_t GetThres() const { return fSamples.thres; }
       Float_t GetChanTomV() const { return fSamples.ChanTomV; }
+      Float_t GetAmpCal() const { return fSamples.acal; }
+      Float_t GetTrigCal() const { return fSamples.trigcal; }
       UInt_t GetFixThresBin() const { return fSamples.FixThresBin; }
       UInt_t GetNSB() const { return fSamples.NSB; }
       UInt_t GetNSA() const { return fSamples.NSA; }
@@ -217,6 +223,7 @@ namespace SBSData {
       void SetTimeCal(Float_t var) { fSamples.tcal = var; }
       void SetGoodTimeCut(Float_t var) { fSamples.GoodTimeCut = var; }
       void SetAmpCal(Float_t var) { fSamples.acal = var; }
+      void SetTrigCal(Float_t var) { fSamples.trigcal = var; }
       void SetGoodHit(Int_t i) { fSamples.good_hit = i; }
       void SetWaveformParam(Float_t var,Int_t i1,Int_t i2,Int_t i3, Int_t i4) { fSamples.thres = var;fSamples.FixThresBin=i1;fSamples.NSB=i2;fSamples.NSA=i3;fSamples.NPedBin=i4;}
       // Process data sets raw value, ped-subtracted and calibrated data

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -391,6 +391,7 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
   // ADC and TDC reference time parameters
   std::vector<Float_t> reftdc_offset, reftdc_cal, reftdc_GoodTimeCut;
   std::vector<Float_t> refadc_ped, refadc_gain, refadc_conv, refadc_thres, refadc_GoodTimeCut;
+  std::vector<Float_t> refadc_AmpToIntRatio;
   std::vector<Int_t> refadc_FixThresBin,refadc_NSB,refadc_NSA,refadc_NPedBin;
 
   // Read calibration parameters
@@ -398,6 +399,7 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
   // (should be organized by logical channel number, according to channel map)
   std::vector<Float_t>  tdc_offset, tdc_cal, tdc_GoodTimeCut;
   std::vector<Float_t> adc_ped, adc_gain, adc_conv, adc_thres, adc_GoodTimeCut;
+  std::vector<Float_t> adc_AmpToIntRatio;
   std::vector<Int_t> adc_FixThresBin,adc_NSB,adc_NSA,adc_NPedBin;
   std::vector<DBRequest> vr;
   if(WithADC()) {
@@ -405,6 +407,7 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
     vr.push_back({ "adc.gain",     &adc_gain,   kFloatV, 0, 1 });
     vr.push_back({ "adc.conv",     &adc_conv,   kFloatV, 0, 1 });
     vr.push_back({ "adc.thres",     &adc_thres,   kFloatV, 0, 1 });
+    vr.push_back({ "adc.AmpToIntRatio",     &adc_AmpToIntRatio,   kFloatV, 0, 1 });
     vr.push_back({ "adc.FixThresBin",     &adc_FixThresBin,   kIntV, 0, 1 });
     vr.push_back({ "adc.NSB",     &adc_NSB,   kIntV, 0, 1 });
     vr.push_back({ "adc.NSA",     &adc_NSA,   kIntV, 0, 1 });
@@ -415,6 +418,7 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
     vr.push_back({ "refadc.gain",     &refadc_gain,   kFloatV, 0, 1 });
     vr.push_back({ "refadc.conv",     &refadc_conv,   kFloatV, 0, 1 });
     vr.push_back({ "refadc.thres",     &refadc_thres,   kFloatV, 0, 1 });
+    vr.push_back({ "refadc.AmpToIntRatio",     &refadc_AmpToIntRatio,   kFloatV, 0, 1 });
     vr.push_back({ "refadc.FixThresBin",     &refadc_FixThresBin,   kIntV, 0, 1 });
     vr.push_back({ "refadc.NSB",     &refadc_NSB,   kIntV, 0, 1 });
     vr.push_back({ "refadc.NSA",     &refadc_NSA,   kIntV, 0, 1 });
@@ -530,6 +534,18 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
     return kInitError;
   }
 
+  if(refadc_AmpToIntRatio.size() == 0) { // expand vector to specify calibration for all elements
+    ResetVector(refadc_AmpToIntRatio,Float_t(1.0),NRefADCElem);    
+  } else if(refadc_AmpToIntRatio.size() == 1) { // expand vector to specify calibration for all elements
+    Float_t temp=refadc_AmpToIntRatio[0];
+    ResetVector(refadc_AmpToIntRatio,temp,NRefADCElem);    
+    std::cout << "set all elements  AmpToIntRatio = " << refadc_AmpToIntRatio[0] << std::endl;
+  } else if ( refadc_AmpToIntRatio.size() != NRefADCElem ) {
+    Error( Here(here), "Inconsistent number of refadc.AmpToIntRatio specified. Expected "
+        "%d but got %d",int(refadc_AmpToIntRatio.size()),NRefADCElem);
+    return kInitError;
+  }
+
   if(refadc_NSB.size() == 0) { // expand vector to specify calibration for all elements
     ResetVector(refadc_NSB,3,NRefADCElem);    
   } else if(refadc_NSB.size() == 1) { // expand vector to specify calibration for all elements
@@ -605,11 +621,15 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
               el->SetWaveform(refadc_ped[nr],refadc_gain[nr],refadc_conv[nr],refadc_GoodTimeCut[nr]);
 	      SBSData::Waveform *wave = el->Waveform();
               wave->SetWaveformParam(refadc_thres[nr],refadc_FixThresBin[nr],refadc_NSB[nr],refadc_NSA[nr],refadc_NPedBin[nr]);
+	      wave->SetAmpCal(refadc_AmpToIntRatio[nr]*refadc_gain[nr]);
+	      wave->SetTrigCal(1.);
             } else {
               el->SetADC(refadc_ped[nr],refadc_gain[nr]);
 	      if( fModeADC == SBSModeADC::kADC ) {
 		SBSData::ADC *fadc=el->ADC();
 		fadc->SetADCParam(refadc_conv[nr],refadc_NSB[nr],refadc_NSA[nr],refadc_NPedBin[nr],refadc_GoodTimeCut[nr]);
+		fadc->SetAmpCal(refadc_AmpToIntRatio[nr]*refadc_gain[nr]);
+	        fadc->SetTrigCal(1.);
 	      }
             }
       }
@@ -693,6 +713,19 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
   } else if ( adc_conv.size() != fNelem ) {
     Error( Here(here), "Inconsistent number of adc.conv specified. Expected "
         "%d but got %d",int(adc_conv.size()),fNelem);
+    return kInitError;
+  }
+
+
+  if(adc_AmpToIntRatio.size() == 0) { // expand vector to specify calibration for all elements
+    ResetVector(adc_AmpToIntRatio,Float_t(1.0),fNelem);    
+  } else if(adc_AmpToIntRatio.size() == 1) { // expand vector to specify calibration for all elements
+    Float_t temp=adc_AmpToIntRatio[0];
+    ResetVector(adc_AmpToIntRatio,temp,fNelem);    
+    std::cout << "set all elements  AmpToIntRatio = " << adc_AmpToIntRatio[0] << std::endl;
+  } else if ( adc_AmpToIntRatio.size() != fNelem ) {
+    Error( Here(here), "Inconsistent number of adc.AmpToIntRatio specified. Expected "
+        "%d but got %d",int(adc_AmpToIntRatio.size()),fNelem);
     return kInitError;
   }
 
@@ -789,11 +822,15 @@ Int_t SBSGenericDetector::ReadDatabase( const TDatime& date )
               e->SetWaveform(adc_ped[k],adc_gain[k],adc_conv[k],adc_GoodTimeCut[k]);
 	      SBSData::Waveform *wave = e->Waveform();
               wave->SetWaveformParam(adc_thres[k],adc_FixThresBin[k],adc_NSB[k],adc_NSA[k],adc_NPedBin[k]);
+	      wave->SetAmpCal(adc_AmpToIntRatio[k]*adc_gain[k]);
+	      wave->SetTrigCal(1.);
             } else {
               e->SetADC(adc_ped[k],adc_gain[k]);
 	      if( fModeADC == SBSModeADC::kADC ) {
 		SBSData::ADC *fadc=e->ADC();
 		fadc->SetADCParam(adc_conv[k],adc_NSB[k],adc_NSA[k],adc_NPedBin[k],adc_GoodTimeCut[k]);
+	        fadc->SetAmpCal(adc_AmpToIntRatio[k]*adc_gain[k]);
+	      fadc->SetTrigCal(1.);
 	      }
             }
           }
@@ -875,6 +912,7 @@ Int_t SBSGenericDetector::DefineVariables( EMode mode )
     if(fModeADC != SBSModeADC::kADCSimple) {
       ve.push_back( {"Ref.a_amp","Ref ADC pulse amplitude", "fRefGood.a_amp"} );
       ve.push_back( {"Ref.a_amp_p","Ref ADC pulse amplitude -ped", "fRefGood.a_amp_p"} );
+      ve.push_back( {"Ref.a_amp_c","(Ref ADC pulse amplitude -ped)*gain*AmpToIntRatio", "fRefGood.a_amp_c"} );
       ve.push_back( {"Ref.a_time","REf ADC pulse time", "fRefGood.a_time"} );
     }
     if(fStoreRawHits) {
@@ -899,6 +937,9 @@ Int_t SBSGenericDetector::DefineVariables( EMode mode )
     if(fModeADC != SBSModeADC::kADCSimple) {
       ve.push_back( {"a_amp","ADC pulse amplitude", "fGood.a_amp"} );
       ve.push_back( {"a_amp_p","ADC pulse amplitude -ped", "fGood.a_amp_p"} );
+      ve.push_back( {"a_amp_c","(ADC pulse amplitude -ped)*gain*AmpToIntRatio", "fGood.a_amp_p"} );
+      ve.push_back( {"a_amptrig_p","(ADC pulse amplitude -ped)*AmpToIntRatio", "fGood.a_amp_p"} );
+      ve.push_back( {"a_amptrig_c","(ADC pulse amplitude -ped)*gain*AmpToIntRatio", "fGood.a_amp_p"} );
       ve.push_back( {"a_time","ADC pulse time", "fGood.a_time"} );
     }
     if(fStoreRawHits) {
@@ -1236,13 +1277,18 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
           fRefGood.a_mult.push_back(blk->ADC()->GetNHits());
           if (fModeADC == SBSModeADC::kADCSimple) fRefGood.a_p.push_back(hit.integral.raw-ped);
 	  if (fModeADC == SBSModeADC::kADC) {
-	    Double_t conv=blk->ADC()->GetGain();
-	      fRefGood.a_p.push_back(hit.integral.val/conv); // ped subtracted with Gain factor
+	    Double_t gain=blk->ADC()->GetGain();
+	      fRefGood.a_p.push_back(hit.integral.val/gain); // ped subtracted with Gain factor
 	  }
           fRefGood.a_c.push_back(hit.integral.val);
           if(fModeADC == SBSModeADC::kADC) { // Amplitude and time are also available
             fRefGood.a_amp.push_back(hit.amplitude.raw);
-            fRefGood.a_amp_p.push_back(hit.amplitude.val);
+	    Double_t again=blk->ADC()->GetAmpCal();	      
+	    Double_t trigcal=blk->ADC()->GetTrigCal();	      
+	    fRefGood.a_amp_p.push_back(hit.integral.val/again); // ped subtracted with Gain factor
+            fRefGood.a_amp_c.push_back(hit.amplitude.val);
+	    fRefGood.a_amptrig_p.push_back(hit.integral.val/again*trigcal); // ped subtracted with Gain factor
+            fRefGood.a_amptrig_c.push_back(hit.amplitude.val*trigcal);
             fRefGood.a_time.push_back(hit.time.val);
           }
 	  } else if ( fStoreEmptyElements ) {
@@ -1258,6 +1304,9 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
           if(fModeADC == SBSModeADC::kADC) { // Amplitude and time are also available
             fRefGood.a_amp.push_back(0.);
             fRefGood.a_amp_p.push_back(0.);
+            fRefGood.a_amp_c.push_back(0.);
+            fRefGood.a_amptrig_p.push_back(0.);
+            fRefGood.a_amptrig_c.push_back(0.);
             fRefGood.a_time.push_back(0.);
           }
  	    
@@ -1304,7 +1353,12 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
         fRefGood.a_p.push_back(wave->GetIntegral().val/gain);
         fRefGood.a_c.push_back(wave->GetIntegral().val);
         fRefGood.a_amp.push_back(wave->GetAmplitude().raw);
-        fRefGood.a_amp_p.push_back(wave->GetAmplitude().val);
+	    Double_t again=wave->GetAmpCal();	      
+	    Double_t trigcal=wave->GetTrigCal();	      
+        fRefGood.a_amp_p.push_back(wave->GetAmplitude().val/again);
+        fRefGood.a_amp_c.push_back(wave->GetAmplitude().val);
+        fRefGood.a_amptrig_p.push_back(wave->GetAmplitude().val/again*trigcal);
+        fRefGood.a_amptrig_c.push_back(wave->GetAmplitude().val*trigcal);
         fRefGood.a_time.push_back(wave->GetTime().val);
 	  } else if (fStoreEmptyElements) {
              fRefGood.ADCrow.push_back(blk->GetRow());
@@ -1314,10 +1368,14 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
         fRefGood.a_mult.push_back(0);
         fRefGood.ped.push_back(wave->GetPed());
         fRefGood.a.push_back(wave->GetIntegral().raw);
-        fRefGood.a_p.push_back(wave->GetIntegral().val);
+        Float_t gain= wave->GetGain();
+        fRefGood.a_p.push_back(wave->GetIntegral().val/gain);
         fRefGood.a_c.push_back(wave->GetIntegral().val);
             fRefGood.a_amp.push_back(0.0);
             fRefGood.a_amp_p.push_back(0.0);
+            fRefGood.a_amp_c.push_back(0.0);
+            fRefGood.a_amptrig_p.push_back(0.0);
+            fRefGood.a_amptrig_c.push_back(0.0);
             fRefGood.a_time.push_back(0.0);
 	  }
 	}
@@ -1395,13 +1453,18 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
           fGood.a_mult.push_back(blk->ADC()->GetNHits());
           if (fModeADC == SBSModeADC::kADCSimple) fGood.a_p.push_back(hit.integral.raw-ped);
 	  if (fModeADC == SBSModeADC::kADC) {
-	    Double_t conv=blk->ADC()->GetGain();
-	      fGood.a_p.push_back(hit.integral.val/conv); // ped subtracted with Gain factor
+	    Double_t gain=blk->ADC()->GetGain();
+	      fGood.a_p.push_back(hit.integral.val/gain); // ped subtracted with Gain factor
 	  }
           fGood.a_c.push_back(hit.integral.val);
           if(fModeADC == SBSModeADC::kADC) { // Amplitude and time are also available
             fGood.a_amp.push_back(hit.amplitude.raw);
-            fGood.a_amp_p.push_back(hit.amplitude.val);
+	    Double_t again=blk->ADC()->GetAmpCal();	      
+	    Double_t trigcal=blk->ADC()->GetTrigCal();	      
+            fGood.a_amp_p.push_back(hit.amplitude.val/again);
+            fGood.a_amp_c.push_back(hit.amplitude.val);
+            fGood.a_amptrig_p.push_back(hit.amplitude.val/again*trigcal);
+            fGood.a_amptrig_c.push_back(hit.amplitude.val*trigcal);
             fGood.a_time.push_back(hit.time.val);
           }
 	  } else if ( fStoreEmptyElements ) {
@@ -1417,6 +1480,9 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
           if(fModeADC == SBSModeADC::kADC) { // Amplitude and time are also available
             fGood.a_amp.push_back(0.);
             fGood.a_amp_p.push_back(0.);
+            fGood.a_amp_c.push_back(0.);
+            fGood.a_amptrig_p.push_back(0.);
+            fGood.a_amptrig_c.push_back(0.);
             fGood.a_time.push_back(0.);
           }
  	    
@@ -1463,7 +1529,12 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
         fGood.a_p.push_back(wave->GetIntegral().val/gain);
         fGood.a_c.push_back(wave->GetIntegral().val);
         fGood.a_amp.push_back(wave->GetAmplitude().raw);
-        fGood.a_amp_p.push_back(wave->GetAmplitude().val);
+	    Double_t again=wave->GetAmpCal();	      
+	    Double_t trigcal=wave->GetTrigCal();	      
+        fGood.a_amp_p.push_back(wave->GetAmplitude().val/again);
+        fGood.a_amp_c.push_back(wave->GetAmplitude().val);
+        fGood.a_amptrig_p.push_back(wave->GetAmplitude().val/again*trigcal);
+        fGood.a_amptrig_c.push_back(wave->GetAmplitude().val*trigcal);
         fGood.a_time.push_back(wave->GetTime().val);
 	  } else if (fStoreEmptyElements) {
              fGood.ADCrow.push_back(blk->GetRow());
@@ -1473,10 +1544,14 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
         fGood.a_mult.push_back(0);
         fGood.ped.push_back(wave->GetPed());
         fGood.a.push_back(wave->GetIntegral().raw);
-        fGood.a_p.push_back(wave->GetIntegral().val);
+        Float_t gain= wave->GetGain();
+        fGood.a_p.push_back(wave->GetIntegral().val/gain);
         fGood.a_c.push_back(wave->GetIntegral().val);
             fGood.a_amp.push_back(0.0);
             fGood.a_amp_p.push_back(0.0);
+            fGood.a_amp_c.push_back(0.0);
+            fGood.a_amptrig_p.push_back(0.0);
+            fGood.a_amptrig_c.push_back(0.0);
             fGood.a_time.push_back(0.0);
 	}
 	}

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -66,6 +66,9 @@ struct SBSGenericOutputData {
   std::vector<Float_t> a_c;         //< [] (ADC integral -pedestal)*calib
   std::vector<Float_t> a_amp;     //< [] ADC pulse amplitude
   std::vector<Float_t> a_amp_p;     //< [] ADC pulse amplitude -pedestal
+  std::vector<Float_t> a_amp_c;     //< [] ADC pulse amplitude -pedestal
+  std::vector<Float_t> a_amptrig_p;     //< [] ADC pulse amplitude -pedestal
+  std::vector<Float_t> a_amptrig_c;     //< [] ADC pulse amplitude -pedestal
   std::vector<Float_t> a_time;    //< [] ADC pulse time
   // TDC variables
   std::vector<Int_t> t_mult;         //< [] TDC # of hits per channel
@@ -95,6 +98,9 @@ struct SBSGenericOutputData {
     a_c.clear();
     a_amp.clear();
     a_amp_p.clear();
+    a_amp_c.clear();
+    a_amptrig_p.clear();
+    a_amptrig_c.clear();
     a_time.clear();
     t.clear();
     t_mult.clear();


### PR DESCRIPTION
SBSData.cxx
1) Modify ADC and Waveform Process so that amplitude val uses acal as the amplitude gain factor.

SBSData.h
1) Add variable trigcal ( Trig amp/ Fadc amp ratio)
2) Add method GetTrigCal and SetTrigCal.
3) Add method GetAmpCal to the Waveform

SBSGenericDetector.h
1) Add variable a_amp_c to SBSGenericOutputData
2) Add variables a_amptrig_p and a_amptrig_c to SBSGenericOutputData


SBSGenericDetector.cxx
1) Add parameters refadc_AmpToIntRatio and adc_AmpToIntRatio
    By default there are set to 1.
2) After creating the SBSElement set the Amplitude cal to
AmpToIntRatio*gain and set the trigger ratio to 1.
The trigger ratio is read in in the SBSCalorimeter readdatabase.
3) In DefineVariables method, add tree variables a_amp_c. a_amptrig_p,
a_amptrig_c
4) In CoarseProcess method, fill the fGood variables a_amp_c
, a_amptrig_p and a_amptrig_c


SBSCalorimeter
1) In ReadDatabase method, set the trigger ratio for the element
to the parameter trigtoFADCratio, if it is in the database.