### PR TITLE
Correct problem with element ID in the Calorimeter Cluster

### DIFF
--- a/SBSBBShower.cxx
+++ b/SBSBBShower.cxx
@@ -192,11 +192,7 @@ void SBSBBShower::MakeMainCluster()
     fMainclus.n.push_back(clus->GetMult());
     fMainclus.blk_e.push_back(clus->GetEblk());
     fMainclus.blk_e_c.push_back(clus->GetEblk()*(fConst + fSlope*fAccCharge));
-    if(clus->GetMaxElement()){
-      fMainclus.id.push_back(clus->GetMaxElement()->GetID());
-    }else{
-       fMainclus.id.push_back(-1);
-    }
+    fMainclus.id.push_back(clus->GetElemID());
     fMainclus.row.push_back(clus->GetRow());
     fMainclus.col.push_back(clus->GetCol());
   }

--- a/SBSBBTotalShower.cxx
+++ b/SBSBBTotalShower.cxx
@@ -151,6 +151,7 @@ exit:
 //_____________________________________________________________________________
 Int_t SBSBBTotalShower::Decode( const THaEvData& evdata )
 {
+  ClearEvent();
   fShower->Decode(evdata);
   fPreShower->Decode(evdata);
   return 0;

--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -381,11 +381,7 @@ Int_t SBSCalorimeter::FindClusters()
     fMainclus.n.push_back(clus->GetMult());
     fMainclus.blk_e.push_back(clus->GetEblk());
     fMainclus.blk_e_c.push_back(clus->GetEblk()*(fConst + fSlope*fAccCharge));
-    if(clus->GetMaxElement()){
-      fMainclus.id.push_back(clus->GetMaxElement()->GetID());
-    }else{
-      fMainclus.id.push_back(-1);
-    }
+    fMainclus.id.push_back(clus->GetElemID());
     fMainclus.row.push_back(clus->GetRow());
     fMainclus.col.push_back(clus->GetCol());
   }
@@ -447,11 +443,7 @@ Int_t SBSCalorimeter::FineProcess(TClonesArray& array)//tracks)
         fOutclus.blk_e_c.push_back(cluster->GetEblk()*(fConst + fSlope*fAccCharge));
         fOutclus.row.push_back(cluster->GetRow());
         fOutclus.col.push_back(cluster->GetCol());
-	if(cluster->GetMaxElement()){
-	  fOutclus.id.push_back(cluster->GetMaxElement()->GetID());
-	}else{
-	  fOutclus.id.push_back(-1);
-	}
+        fOutclus.id.push_back(cluster->GetElemID());
       }
       nclus++;
     }

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -28,6 +28,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
     fMult = 1;
     fRow  = block->GetRow();
     fCol  = block->GetCol();
+    fElemID  = block->GetID();
 }
 
 
@@ -44,6 +45,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk)
     fMult = 0;
     fRow  = -1;
     fCol  = -1;
+    fElemID  = -1;
     fMaxElement = 0;
 }
 
@@ -57,6 +59,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster() {
     fMult = 0;
     fRow  = -1;
     fCol  = -1;
+    fElemID  = -1;
 }
 
 //_____________________________________________________________
@@ -77,6 +80,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
           fEblk = block->GetE();
           fRow = block->GetRow();
           fCol = block->GetCol();
+          fElemID = block->GetID();
         }
         // Keep a pointer to the element with the highest energy
         if(!fMaxElement) {

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -26,6 +26,7 @@ public:
     Int_t   GetMult() const {return fMult;}
     Int_t   GetRow()  const {return fRow; }
     Int_t   GetCol()  const {return fCol; }
+    Int_t   GetElemID()  const {return fElemID; }
     SBSElement* GetMaxElement() { return fMaxElement; }
     Float_t GetMaxE() const {if(fMaxElement) return fMaxElement->GetE(); return 0; }
 
@@ -38,6 +39,7 @@ public:
     void SetMult(Int_t var) {fMult=var;}
     void SetRow(Int_t var) { fRow=var; }
     void SetCol(Int_t var) { fCol=var; }
+    void SetElemID(Int_t var) { fElemID=var; }
 
     SBSElement* GetElement(UInt_t i);
     std::vector<SBSElement*>& GetElements() {return fElements;}
@@ -57,6 +59,7 @@ private:
     Float_t fEblk;    // Energy of block with highest E
     Int_t   fRow;     // Row of block with highest E
     Int_t   fCol;     // Row of block with highest E
+    Int_t   fElemID;     // ElemID of block with highest E
 
     Int_t fMult;      // Number of blocks in the cluster
     Int_t fNMaxElements;// Max number of blocks


### PR DESCRIPTION
SBSCalorimeter.h
1) add fElemID and method GetElemID, SetElemID

SBSCalorimeter.cxx
1) Modified to fill the fElemID with the block elment ID of the
block with the highest energy.

SBSCalorimeter::FindClusters
1) fill fMainclus.id with GetElemID()
2) fill fOutclus.id with GetElemID()

SBSBBShower::MakeMainCluster
1) fill fMainclus.id with GetElemID() , this is used for PreShower

SBSBBTotalShower::Decode
1) add call to ClearEvent