### PR TITLE
Update to include ADC time of max block in the calo cluster information

### DIFF
--- a/SBSBBShower.cxx
+++ b/SBSBBShower.cxx
@@ -186,6 +186,7 @@ void SBSBBShower::MakeMainCluster()
   if(fClusters.size()>0) {
     SBSCalorimeterCluster *clus = fClusters[0];
     fMainclus.e.push_back(clus->GetE());
+    fMainclus.atime.push_back(clus->GetAtime());
     fMainclus.e_c.push_back(clus->GetE()*(fConst + fSlope*fAccCharge));
     fMainclus.x.push_back(clus->GetX());
     fMainclus.y.push_back(clus->GetY());

--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -196,6 +196,7 @@ Int_t SBSCalorimeter::DefineVariables( EMode mode )
     { "e",      "Energy (MeV) of largest cluster",    "GetE()" },
     { "e_c",    "Corrected Energy (MeV) of largest cluster",    "GetECorrected()" },
     { "eblk",   "Energy (MeV) of highest energy block in the largest cluster",    "GetEBlk()" },
+    { "atimeblk",   "ADC time of highest energy block in the largest cluster",    "GetAtime()" },
     { "eblk_c", "Corrected Energy (MeV) of highest energy block in the largest cluster",    "GetEBlkCorrected()" },
     { "rowblk", "Row of block with highest energy in the largest cluster",    "GetRow()" },
     { "colblk", "Col of block with highest energy in the largest cluster",    "GetCol()" },
@@ -303,11 +304,13 @@ Int_t SBSCalorimeter::MakeGoodBlocks()
 	 if(fModeADC != SBSModeADC::kWaveform) {
 	   const SBSData::PulseADCData &ahit = blk->ADC()->GetGoodHit();
 	   blk->SetE(ahit.integral.val);
+	   blk->SetAtime(ahit.time.val);
 	   fGoodBlocks.e.push_back(ahit.integral.val);
             fGoodBlocks.ADCTime.push_back(ahit.time.val);
 	 } else {
            SBSData::Waveform *wave = blk->Waveform();
 	   blk->SetE(wave->GetIntegral().val);
+	   blk->SetAtime(wave->GetTime().val);
 	   fGoodBlocks.e.push_back(wave->GetIntegral().val);
            fGoodBlocks.ADCTime.push_back(wave->GetTime().val);
 	 }
@@ -375,6 +378,7 @@ Int_t SBSCalorimeter::FindClusters()
   if(fClusters.size()>0) {
     SBSCalorimeterCluster *clus = fClusters[0];
     fMainclus.e.push_back(clus->GetE());
+    fMainclus.atime.push_back(clus->GetAtime());
     fMainclus.e_c.push_back(clus->GetE()*(fConst + fSlope*fAccCharge));
     fMainclus.x.push_back(clus->GetX());
     fMainclus.y.push_back(clus->GetY());
@@ -406,6 +410,7 @@ Int_t SBSCalorimeter::FineProcess(TClonesArray& array)//tracks)
       for(UInt_t nc=0;nc<clus->GetMult();nc++ ) {
 	SBSElement *blk= clus->GetElement(nc);
         fMainclusblk.e.push_back(blk->GetE());
+        fMainclusblk.atime.push_back(blk->GetAtime());
         fMainclusblk.e_c.push_back(blk->GetE()*(fConst + fSlope*fAccCharge));
         fMainclusblk.x.push_back(blk->GetX());
         fMainclusblk.y.push_back(blk->GetY());
@@ -421,6 +426,7 @@ Int_t SBSCalorimeter::FineProcess(TClonesArray& array)//tracks)
     // Now store the remaining clusters (up to fMaxNclus)
     Int_t nres = TMath::Min(Int_t(fMaxNclus),Int_t(fClusters.size()));
     fOutclus.e.reserve(nres);
+    fOutclus.atime.reserve(nres);
     fOutclus.e_c.reserve(nres);
     fOutclus.x.reserve(nres);
     fOutclus.y.reserve(nres);
@@ -435,6 +441,7 @@ Int_t SBSCalorimeter::FineProcess(TClonesArray& array)//tracks)
     for(SBSCalorimeterCluster *cluster : fClusters) {
       if(nclus < fMaxNclus) { // Keep adding them until we reach fMaxNclus
         fOutclus.e.push_back(cluster->GetE());
+        fOutclus.atime.push_back(cluster->GetAtime());
         fOutclus.e_c.push_back(cluster->GetE()*(fConst + fSlope*fAccCharge));
         fOutclus.x.push_back(cluster->GetX());
         fOutclus.y.push_back(cluster->GetY());

--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -55,6 +55,7 @@ struct SBSCalBlocks {
 
 struct SBSCalorimeterOutput {
   std::vector<Float_t> e;   //< []
+  std::vector<Float_t> atime;   //< []
   std::vector<Float_t> e_c;   //< []
   std::vector<Float_t> x;   //< []
   std::vector<Float_t> y;   //< []
@@ -82,6 +83,7 @@ public:
 
   // Get information from the main cluster
   Float_t GetE();             //< Main cluster energy
+  Float_t GetAtime();         //< Main cluster ADC time of max block
   Float_t GetECorrected();    //< Main cluster corrected energy
   Float_t GetX();             //< Main cluster energy average x
   Float_t GetY();             //< Main cluster energy average y
@@ -204,6 +206,10 @@ inline Int_t SBSCalorimeter::GetVVal(std::vector<Int_t> &v, UInt_t i)
 
 inline Float_t SBSCalorimeter::GetE() {
   return GetVVal(fMainclus.e);
+}
+
+inline Float_t SBSCalorimeter::GetAtime() {
+  return GetVVal(fMainclus.atime);
 }
 
 inline Float_t SBSCalorimeter::GetECorrected() {

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -26,8 +26,9 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
     fE = block->GetE();
     fEblk = block->GetE();
     fMult = 1;
+    fAtime  = block->GetAtime();
     fRow  = block->GetRow();
-    fCol  = block->GetCol();
+     fCol  = block->GetCol();
     fElemID  = block->GetID();
 }
 
@@ -43,6 +44,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk)
     fE = 0;
     fEblk = 0;
     fMult = 0;
+    fAtime = 0;
     fRow  = -1;
     fCol  = -1;
     fElemID  = -1;
@@ -57,6 +59,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster() {
     fE = kBig;
     fEblk = 0;
     fMult = 0;
+    fAtime = 0;
     fRow  = -1;
     fCol  = -1;
     fElemID  = -1;
@@ -78,6 +81,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
         fE += block->GetE();
         if(block->GetE() > fEblk) {
           fEblk = block->GetE();
+          fAtime = block->GetAtime();
           fRow = block->GetRow();
           fCol = block->GetCol();
           fElemID = block->GetID();
@@ -96,6 +100,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
 void SBSCalorimeterCluster::ClearEvent() {
     fMult=0;fX=fY=fE=0.;
     fEblk=0;
+    fAtime=0;
     fRow=fCol=-1;
     fMaxElement = 0;
     fElements.clear();

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -22,6 +22,7 @@ public:
     Float_t GetX() const {return fX;}
     Float_t GetY() const {return fY;}
     Float_t GetE() const {return fE;}
+    Float_t GetAtime() const {return fAtime;}
     Float_t GetEblk() const {return fEblk;}
     Int_t   GetMult() const {return fMult;}
     Int_t   GetRow()  const {return fRow; }
@@ -35,6 +36,7 @@ public:
     void SetX(Float_t var) {fX=var;}
     void SetY(Float_t var) {fY=var;}
     void SetE(Float_t var) {fE=var;}
+    void SetAtime(Float_t var) {fAtime=var;}
     void SetEblk(Float_t var) {fEblk=var;}
     void SetMult(Int_t var) {fMult=var;}
     void SetRow(Int_t var) { fRow=var; }
@@ -56,6 +58,7 @@ private:
     Float_t fY;       // y position of the center
 
     Float_t fE;       // Energy deposit in block
+    Float_t fAtime;       // ADC time  of block with highest E
     Float_t fEblk;    // Energy of block with highest E
     Int_t   fRow;     // Row of block with highest E
     Int_t   fCol;     // Row of block with highest E

--- a/SBSElement.h
+++ b/SBSElement.h
@@ -26,6 +26,7 @@ public:
   Float_t GetY()     const { return fY; }
   Float_t GetZ()     const { return fZ; }
   Float_t GetE()     const { return fE; }
+  Float_t GetAtime()     const { return fAtime; }
   Int_t   GetRow()   const { return fRow; }
   Int_t   GetCol()   const { return fCol; }
   Int_t   GetLayer() const { return fLayer; }
@@ -40,6 +41,7 @@ public:
   void SetY(Float_t var)    { fY = var; }
   void SetZ(Float_t var)    { fZ = var; }
   void SetE(Float_t var)    { fE = var; }
+  void SetAtime(Float_t var)    { fAtime = var; }
   void SetRow(Int_t var)    { fRow = var; }
   void SetCol(Int_t var)    { fCol = var; }
   void SetLayer(Int_t var)  { fLayer = var; }
@@ -62,6 +64,7 @@ protected:
   Float_t fY;       ///< relative y position of the center
   Float_t fZ;       ///< relative z position of the center
   Float_t fE;       ///< calibrated energy of event in this block
+  Float_t fAtime;       ///< ADC time of event in this block
 
   Int_t   fRow;     ///< Row of the block
   Int_t   fCol;     ///< Column of the block


### PR DESCRIPTION
SBSCalorimeterCluster
1) adds method GetAtime() and SetAtime with variable fAtime
2) Default fill fAtime=0 when cluster created
3) In AddElement fill fAtime for the block with max E.
SBSElement
1) Add SetAtime(), GetAtime(). Used in SBSCalorimeter::MakeGoodBlocks
2) add variable fAtime ADC time of event in this block


SBSCalorimeter
1) Add atime to struct SBSCalorimeterOutput
2) add methods GetAtime(), SetAtime() for ADC time of max block
3) add to the tree
"atimeblk",   "ADC time of highest energy block in the largest cluster
4) In SBSCalorimeter::MakeGoodBlocks fill the ADC time for the block element
5) Fill fMainclus, fMainclusblk and fOutclus with the Atime

SBSBBShower
1) Add atime to MakeMainCluster