### PR TITLE
Modify SBSGenericDetector::CoarseProcess

### DIFF
--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -1225,7 +1225,7 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
   for(Int_t k = 0; k < fNRefElem; k++) {
     blk = fRefElements[k];
     if(!blk) continue;
-    if(WithTDC()) {
+    if(WithTDC() && !fDisableRefTDC ) {
       if ( blk->TDC()->HasData()) {
     fRefGood.TDCrow.push_back(blk->GetRow());
     fRefGood.TDCcol.push_back(blk->GetCol());
@@ -1263,8 +1263,8 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
 	}
     }
     //
-    if(WithADC() && blk->HasADCData()) {
-      if (fModeADC == SBSModeADC::kADC && blk->ADC()->HasData()) {
+    if(WithADC() && !fDisableRefADC ) {
+      if (fModeADC == SBSModeADC::kADC) {
           if(blk->ADC()->HasData() && blk->ADC()->GetGoodHitIndex() >=0){
              fRefGood.ADCrow.push_back(blk->GetRow());
              fRefGood.ADCcol.push_back(blk->GetCol());
@@ -1321,7 +1321,7 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
               fRefRaw.a_time.push_back(hit.time.val);
              }
           }
-    } else if  (fModeADC == SBSModeADC::kWaveform && blk->Waveform()->HasData()){ // Waveform mode
+    } else if  (fModeADC == SBSModeADC::kWaveform ){ // Waveform mode
         SBSData::Waveform *wave = blk->Waveform();
 	if(wave->HasData()) {		
           if(fStoreRawHits) {


### PR DESCRIPTION
Fixed problem with filling the fRefGood vectors when the
detector had ADC and TDC but only set the reference time for
one of them