### PR TITLE
Valgrind fixes

### DIFF
--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -155,7 +155,7 @@ namespace SBSData {
     Double_t ThresVal=GetThres(); // mV
     UInt_t ThresCrossBin=TMath::Max(NPedsum-1,0);
     //    std::cout << " ped = " << fSamples.ped << " thres = " << ThresVal << std::endl ;
-    while ( fSamples.samples_raw[ThresCrossBin] < fSamples.ped+ThresVal && ThresCrossBin < vals.size() ) {
+    while ( ThresCrossBin < vals.size() && fSamples.samples_raw[ThresCrossBin] < fSamples.ped+ThresVal ) {
         ThresCrossBin++;
     }
      //

--- a/SBSTimingHodoscope.cxx
+++ b/SBSTimingHodoscope.cxx
@@ -892,8 +892,8 @@ void SBSTimingHodoscope::ClearEvent()
   fGoodBarADCRa.clear();
   fGoodBarADCRap.clear();
   fGoodBarADCRac.clear();
-  
-  fClusters.clear();
+
+  DeleteContainer(fClusters);
   
   /*
   fClusterMult.clear();
@@ -932,6 +932,7 @@ SBSTimingHodoscope::~SBSTimingHodoscope()
   DeleteContainer(fBars);
   DeleteContainer(fPMTMapL);
   DeleteContainer(fPMTMapR);
+  DeleteContainer(fClusters);
 }
 
 SBSTimingHodoscopeCluster* SBSTimingHodoscope::GetCluster(int i)

--- a/SBSTimingHodoscope.cxx
+++ b/SBSTimingHodoscope.cxx
@@ -467,7 +467,7 @@ Int_t SBSTimingHodoscope::CoarseProcess( TClonesArray& tracks )
 	fGoodBarTDCRteW.push_back(RteW);
 	fGoodBarTDCRtot.push_back(hitR.te.val-hitR.le.val);
 	fGoodBarTDCRtotW.push_back(RteW-RleW);
-	
+
 	fGoodBarTDCmean.push_back(barmeantime);
 	fGoodBarTDCdiff.push_back(bartimediff);
 	
@@ -609,7 +609,7 @@ Int_t SBSTimingHodoscope::DoClustering()
     //<< fGoodBarTDCRtotW[i]+fGoodBarTDCLtotW[i] << std::endl;
     //find local maximum first:
     // check for the "middle" elements
-    if(0<i && i<fGoodBarIDsTDC.size()-1){
+    if(0<i && i+1<fGoodBarIDsTDC.size()){
       // if the considered element has larger Time over Threshold than both its direct neighbors, it is considered a local maximum
       if( (fGoodBarTDCRtotW[i]+fGoodBarTDCLtotW[i])>(fGoodBarTDCRtotW[i-1]+fGoodBarTDCLtotW[i-1]) && (fGoodBarTDCRtotW[i]+fGoodBarTDCLtotW[i])>(fGoodBarTDCRtotW[i+1]+fGoodBarTDCLtotW[i+1]) ){
 	//std::cout << " case 1 " << std::endl;
@@ -634,7 +634,7 @@ Int_t SBSTimingHodoscope::DoClustering()
 	SBSTimingHodoscopeCluster* clus = new SBSTimingHodoscopeCluster(fClusMaxSize, Bar);
 	fClusters.push_back(clus);
       }
-    }else if(i==0){
+    }else if(i==0 && i+1<fGoodBarIDsTDC.size()){
       if( (fGoodBarTDCRtotW[i]+fGoodBarTDCLtotW[i])>(fGoodBarTDCRtotW[i+1]+fGoodBarTDCLtotW[i+1]) || fGoodBarIDsTDC[i+1]-baridx>1 ){
 	//check for first element
 	//std::cout << " case 5 " << std::endl;
@@ -642,7 +642,7 @@ Int_t SBSTimingHodoscope::DoClustering()
 	SBSTimingHodoscopeCluster* clus = new SBSTimingHodoscopeCluster(fClusMaxSize, Bar);
 	fClusters.push_back(clus);
       }
-    }else if(i==fGoodBarIDsTDC.size()-1){
+    }else if(i>0 && i+1==fGoodBarIDsTDC.size()){
       if( (fGoodBarTDCRtotW[i]+fGoodBarTDCLtotW[i])>(fGoodBarTDCRtotW[i-1]+fGoodBarTDCLtotW[i-1]) || baridx-fGoodBarIDsTDC[i-1]>1 ){
 	//check for last element
 	//std::cout << " case 6 " << std::endl;


### PR DESCRIPTION
Fixes a few small memory leaks and bad array accesses found by valgrind memcheck.

Someone should take a look at SBSTimingHodoscope::DoClustering and decide what to do in the degenerate case where fGoodBarIDsTDC.size() == 1. Currently, the result is that no clusters are generated, i.e. fClusters is empty on exit. This is probably not quite correct, but I didn't want to make assumptions on behalf of the detector experts.
