### PR TITLE
CMake: Make RelWithDebInfo the default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 ## Set the default build type
-set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Set build type (Debug is default)")
+set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Set build type (RelWithDebInfo is default)")
 
 set(DEV_WARNING "cmake build of SBS-Offline is still in development. Please test and report issues")
 
@@ -29,8 +29,6 @@ SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-#SET(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 # the RPATH to be used when installing, but only if it's not a system directory
 LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)


### PR DESCRIPTION
By pure accident, I discovered that the default build type was set to "Debug". Someone had later hardcoded "RelWithDebInfo" elsewhere in CMakeLists.txt, which was then removed because hardcoding a variable like this is a bad idea, thus reverting to this default, which is arguably no longer suitable since we're using this repo for production now.
