### PR TITLE
Changes to SBSGenericDetector::DecodeTDC

### DIFF
--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -44,7 +44,11 @@ namespace SBSModeTDC {
     kTDCSimple,  //< Does not contain trailing edge, and hence no ToT info
   };
 }
-
+// structure for sorting TDC hits
+struct TDCHits {
+  UInt_t edge;
+  UInt_t rawtime;
+};
 
 // This structure has output data when the user wants every hit to be stored
 // in the rootfile.


### PR DESCRIPTION
Need to make changes to time order the TDC hit data, since
from the VETROC the hits are not in time order.

Added structure TDCHits to SBSGenericDetector.h

In DecodeTDC :
Fill vector of TDCHits with edge and rawtime of hits
Sort TDCHits vector in ascending order of time
Use TDCHits vector when processing the TDC hits.