### PR TITLE
Make APVMAP a std::array to speed up GetStripNumber

### DIFF
--- a/SBSGEMModule.cxx
+++ b/SBSGEMModule.cxx
@@ -3059,8 +3059,6 @@ double SBSGEMModule::FitStripTime( int striphitindex, double RMS ){
 }
 
 void SBSGEMModule::InitAPVMAP(){
-  APVMAP.clear();
-
   APVMAP[SBSGEM::kINFN].resize(fN_APV25_CHAN);
   APVMAP[SBSGEM::kUVA_XY].resize(fN_APV25_CHAN);
   APVMAP[SBSGEM::kUVA_UV].resize(fN_APV25_CHAN);

--- a/SBSGEMModule.h
+++ b/SBSGEMModule.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <array>
 
 //using namespace std;
 
@@ -189,9 +190,9 @@ class SBSGEMModule : public THaSubDetector {
   std::vector<mpdmap_t>    fMPDmap; //this may need to be modified
   std::vector<Int_t>       fChanMapData;
 
-  UInt_t fAPVmapping; //choose APV channel --> strip mapping; there are only three possible values supported for now (see SBSGEM::APVmap_t)
+  SBSGEM::APVmap_t fAPVmapping; //choose APV channel --> strip mapping; there are only three possible values supported for now (see SBSGEM::APVmap_t)
 
-  std::map<UInt_t, std::vector<UInt_t> > APVMAP;
+  std::array<std::vector<UInt_t>, 4 > APVMAP;
 
   void InitAPVMAP();
   


### PR DESCRIPTION
Map lookups quickly get expensive when done in inner loops ...

This basically trivial change gives a small (5%-ish) speedup in the GEM module decoding.
