### PR TITLE
Fixes to LHRSScalerEvtHandler

### DIFF
--- a/LHRSScalerEvtHandler.cxx
+++ b/LHRSScalerEvtHandler.cxx
@@ -81,7 +81,7 @@ LHRSScalerEvtHandler::LHRSScalerEvtHandler(const char *name, const char* descrip
     dvars(0),fScalerTree(0),fUseFirstEvent(kTRUE),
     fClockChan(-1),fClockFreq(-1),fLastClock(0),fClockOverflows(0),
     fTotalTime(0),fPrevTotalTime(0),fDeltaTime(-1),
-    dvarsFirst(0),dvars_prev_read(0),
+    dvarsFirst(0),dvars_prev_read(0),fPhysicsEventNumber(-1),
     fNumBCMs(0),fbcm_Current_Threshold_Index(0),fbcm_Current_Threshold(0),
     fBCM_Gain(0),fBCM_Offset(0),fBCM_SatOffset(0),fBCM_SatQuadratic(0),fBCM_delta_charge(0)
 {
@@ -184,6 +184,9 @@ Int_t LHRSScalerEvtHandler::Analyze(THaEvData *evdata)
     tinfo = name + "/D";
     fScalerTree->Branch(name.Data(), &evcount, tinfo.Data(), 4000);
 
+    // create the physics event number branch 
+    fScalerTree->Branch("evnum",&fPhysicsEventNumber,"evnum/L");
+
     for (UInt_t i = 0; i < scalerloc.size(); i++) {
       name = scalerloc[i]->name; 
       tinfo = name + "/D";
@@ -202,6 +205,9 @@ Int_t LHRSScalerEvtHandler::Analyze(THaEvData *evdata)
   }
 
   if (fDebugFile) *fDebugFile<<"\n\nLHRSScalerEvtHandler :: Debugging event type "<<dec<<evdata->GetEvType()<<endl<<endl;
+
+  // get the physics event number 
+  fPhysicsEventNumber = evdata->GetEvNum(); 
 
   // local copy of data
   // NOTE: event is ASCII, not 32-bit binary! We need to convert ASCII to 32-bit binary  
@@ -231,7 +237,7 @@ Int_t LHRSScalerEvtHandler::Analyze(THaEvData *evdata)
   UInt_t *p     = A;  
   UInt_t *pstop = p + ndata - 4;  
 
-  char msg[200];  
+  // char msg[200];  
 
   AnalyzeBuffer(ndata,rdata); 
 
@@ -611,7 +617,7 @@ Int_t LHRSScalerEvtHandler::AnalyzeBuffer(Int_t ndata,UInt_t *rdata){
    char *pc      = (char *)P;
    int NWORDS    = ParseData(pc,word,A);
    UInt_t *p     = A;  
-   UInt_t *pstop = p + *p - 4;
+   // UInt_t *pstop = p + *p - 4;
     
    char msg[200];  
 

--- a/LHRSScalerEvtHandler.h
+++ b/LHRSScalerEvtHandler.h
@@ -70,6 +70,7 @@ private:
    Double_t fDeltaTime;
    Double_t *dvarsFirst;
    UInt_t *dvars_prev_read;
+   Long64_t fPhysicsEventNumber;
    Int_t fNumBCMs;
    Int_t fbcm_Current_Threshold_Index;
    Double_t fbcm_Current_Threshold;

--- a/SBSScalerEvtHandler.cxx
+++ b/SBSScalerEvtHandler.cxx
@@ -116,12 +116,12 @@ Int_t SBSScalerEvtHandler::Begin( THaRunBase* rb )
 {
   THaEvtTypeHandler::Begin( rb );
   fIunserVsTime = new TH1D("fIunserVsTime", ";time (s);", 5000, 0, 5000);
-  fIu1VsTime = new TH1D("fIu1VsTime", ";time (s);", 5000, 0, 5000);
-  fIunewVsTime = new TH1D("fIunewVsTime", ";time (s);", 5000, 0, 5000);
-  fIdnewVsTime = new TH1D("fIdnewVsTime", ";time (s);", 5000, 0, 5000);
-  fId1VsTime = new TH1D("fId1VsTime", ";time (s);", 5000, 0, 5000);
-  fId3VsTime = new TH1D("fId3VsTime", ";time (s);", 5000, 0, 5000);
-  fId10VsTime = new TH1D("fId10VsTime", ";time (s);", 5000, 0, 5000);
+  fIu1VsTime    = new TH1D("fIu1VsTime", ";time (s);", 5000, 0, 5000);
+  fIunewVsTime  = new TH1D("fIunewVsTime", ";time (s);", 5000, 0, 5000);
+  fIdnewVsTime  = new TH1D("fIdnewVsTime", ";time (s);", 5000, 0, 5000);
+  fId1VsTime    = new TH1D("fId1VsTime", ";time (s);", 5000, 0, 5000);
+  fId3VsTime    = new TH1D("fId3VsTime", ";time (s);", 5000, 0, 5000);
+  fId10VsTime   = new TH1D("fId10VsTime", ";time (s);", 5000, 0, 5000);
   return 0;
 }
 
@@ -150,13 +150,13 @@ Int_t SBSScalerEvtHandler::End( THaRunBase* )
   double Ntrigs, NtrigsA, Time, BeamCurrent, BeamCharge, LiveTime;
   double clk_cnt = 0, clk_rate = 0, edtm_cnt = 0, unew_cnt = 0, d3_cnt = 0, d10_cnt = 0;
   
-  if(fIunserVsTime!=NULL)fIunserVsTime->Write( 0, kOverwrite );
-  if(fIu1VsTime!=NULL)fIu1VsTime->Write( 0, kOverwrite );
-  if(fIunewVsTime!=NULL)fIunewVsTime->Write( 0, kOverwrite );
-  if(fIdnewVsTime!=NULL)fIdnewVsTime->Write( 0, kOverwrite );
-  if(fId1VsTime!=NULL)fId1VsTime->Write( 0, kOverwrite );
-  if(fId3VsTime!=NULL)fId3VsTime->Write( 0, kOverwrite );
-  if(fId10VsTime!=NULL)fId10VsTime->Write( 0, kOverwrite );
+  if(fIunserVsTime!=NULL) fIunserVsTime->Write( 0, kOverwrite );
+  if(fIu1VsTime!=NULL)    fIu1VsTime->Write( 0, kOverwrite );
+  if(fIunewVsTime!=NULL)  fIunewVsTime->Write( 0, kOverwrite );
+  if(fIdnewVsTime!=NULL)  fIdnewVsTime->Write( 0, kOverwrite );
+  if(fId1VsTime!=NULL)    fId1VsTime->Write( 0, kOverwrite );
+  if(fId3VsTime!=NULL)    fId3VsTime->Write( 0, kOverwrite );
+  if(fId10VsTime!=NULL)   fId10VsTime->Write( 0, kOverwrite );
   
   THaAnalyzer* analyzer = THaAnalyzer::GetInstance();
   if(analyzer!=nullptr){// check that the analyzer actually exists... otherwise, skip
@@ -446,15 +446,15 @@ Int_t SBSScalerEvtHandler::Analyze(THaEvData *evdata)
 	}
 	
       }
-      Time = clk_rate/clk_rate;
+      Time = clk_cnt/clk_rate;
       
-      if(fIunserVsTime!=NULL && Time>0)fIunserVsTime->Fill(Time, unser_rate);
-      if(fIu1VsTime!=NULL && Time>0)fIu1VsTime->Fill(Time, u1_rate);
-      if(fIunewVsTime!=NULL && Time>0)fIunewVsTime->Fill(Time, unew_rate);
-      if(fIdnewVsTime!=NULL && Time>0)fIdnewVsTime->Fill(Time, dnew_rate);
-      if(fId1VsTime!=NULL && Time>0)fId1VsTime->Fill(Time, d1_rate);
-      if(fId3VsTime!=NULL && Time>0)fId3VsTime->Fill(Time, d3_rate);
-      if(fId10VsTime!=NULL && Time>0)fId10VsTime->Fill(Time, d10_rate);
+      if(fIunserVsTime!=NULL && Time>0) fIunserVsTime->Fill(Time, unser_rate);
+      if(fIu1VsTime!=NULL    && Time>0) fIu1VsTime->Fill(Time, u1_rate);
+      if(fIunewVsTime!=NULL  && Time>0) fIunewVsTime->Fill(Time, unew_rate);
+      if(fIdnewVsTime!=NULL  && Time>0) fIdnewVsTime->Fill(Time, dnew_rate);
+      if(fId1VsTime!=NULL    && Time>0) fId1VsTime->Fill(Time, d1_rate);
+      if(fId3VsTime!=NULL    && Time>0) fId3VsTime->Fill(Time, d3_rate);
+      if(fId10VsTime!=NULL   && Time>0) fId10VsTime->Fill(Time, d10_rate);
     }
     return ret;
 

--- a/SBSScalerEvtHandler.cxx
+++ b/SBSScalerEvtHandler.cxx
@@ -79,7 +79,7 @@ SBSScalerEvtHandler::SBSScalerEvtHandler(const char *name, const char* descripti
     fNormSlot(-1),
     dvars(0),dvars_prev_read(0), dvarsFirst(0), fScalerTree(0), fUseFirstEvent(kTRUE),
     fOnlySyncEvents(kFALSE), fOnlyBanks(kFALSE), fDelayedType(-1),
-    fClockChan(-1), fLastClock(0), fClockOverflows(0)
+    fClockChan(-1), fLastClock(0), fClockOverflows(0),fPhysicsEventNumber(-1)
 {
   fRocSet.clear();
   fModuleSet.clear();
@@ -136,7 +136,7 @@ Int_t SBSScalerEvtHandler::End( THaRunBase* )
     AnalyzeBuffer(rdata,kFALSE);
   }
   if (fDebugFile) *fDebugFile << "scaler tree ptr  "<<fScalerTree<<endl;
-  evNumber += 1;
+  // evNumber += 1;
   evNumberR = evNumber;
   if (fScalerTree) fScalerTree->Fill();
 
@@ -351,7 +351,7 @@ Int_t SBSScalerEvtHandler::Analyze(THaEvData *evdata)
   Int_t lfirst=1;
 
   if(evdata->GetEvNum() > 0) {
-    evNumber=evdata->GetEvNum();
+    evNumber  = evdata->GetEvNum();
     evNumberR = evNumber;
   }
   if ( !IsMyEvent(evdata->GetEvType()) ) return -1;
@@ -385,9 +385,12 @@ Int_t SBSScalerEvtHandler::Analyze(THaEvData *evdata)
     tinfo = name + "/D";
     fScalerTree->Branch(name.Data(), &evcountR, tinfo.Data(), 4000);
  
-   name = "evNumber";
+    name = "evNumber";
     tinfo = name + "/D";
     fScalerTree->Branch(name.Data(), &evNumberR, tinfo.Data(), 4000);
+
+    // create a branch for the physics event number
+    fScalerTree->Branch("evnum",&fPhysicsEventNumber,"evnum/L");
 
     for (size_t i = 0; i < scalerloc.size(); i++) {
       name = scalerloc[i]->name;
@@ -396,6 +399,9 @@ Int_t SBSScalerEvtHandler::Analyze(THaEvData *evdata)
     }
 
   }  // if (lfirst && !fScalerTree)
+
+  // get the physics event number 
+  fPhysicsEventNumber = evdata->GetEvNum();
 
   UInt_t *rdata = (UInt_t*) evdata->GetRawDataBuffer();
 

--- a/SBSScalerEvtHandler.h
+++ b/SBSScalerEvtHandler.h
@@ -90,6 +90,7 @@ private:
    Int_t fClockChan;
    UInt_t fLastClock;
    Int_t fClockOverflows;
+   Long64_t fPhysicsEventNumber;
    std::vector<UInt_t*> fDelayedEvents;
    std::set<UInt_t> fRocSet;
    std::set<UInt_t> fModuleSet;


### PR DESCRIPTION
Re-implemented fixes to the LHRSScalerEvtHandler to properly decode inserted scaler events.  Verified the fix with a replayed run to show BCM counts, rates, and currents match for LHRS and SBS scaler tree variables. 