### PR TITLE
Implemented method to use a threshold on total cluster energy. Exampl…

### DIFF
--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -41,8 +41,9 @@ SBSCalorimeter::SBSCalorimeter( const char* name, const char* description,
   fMaxNclus(10), fConst(1.0), fSlope(0.0), fAccCharge(0.0), fDataOutputLevel(1000)
 {
   // Constructor.
-  fEmin = 0.001; // 1 MeV minimum energy to be in cluster  
+  fEmin = 0.001; // 1 MeV minimum energy to be in cluster (Hit threshold)  
   fEmin_clusSeed = 0.001; // 1 MeV minimum energy to be the seed of a cluster
+  fEmin_clusTotal = 0.001; // Minimum total cluster energy is 1 MeV
   fXmax_dis = .30; // Maximum X (m) distance from cluster center to be included in cluster
   fYmax_dis = .30; // Maximum Y (m) distance from cluster center to be included in cluster
   fRmax_dis = .30; // Maximum Radius (m) from cluster center to be included in cluster
@@ -92,6 +93,7 @@ Int_t SBSCalorimeter::ReadDatabase( const TDatime& date )
   DBRequest config_request[] = {
     { "emin",         &fEmin,   kDouble, 0, false }, ///< minimum energy threshold
     { "emin_clSeed", &fEmin_clusSeed, kDouble, 0, false }, ///< minimum cluster seed energy
+    { "emin_clTotal", &fEmin_clusTotal, kDouble, 0, false }, ///< minimum total cluster energy
     { "cluster_dim",   &cluster_dim,   kIntV, 0, true }, ///< cluster dimensions (2D)
     { "nmax_cluster",   &fMaxNclus,   kInt, 0, true }, ///< maximum number of clusters to store
     { "const", &fConst, kDouble, 0, true }, ///< const from gain correction 
@@ -389,6 +391,9 @@ Int_t SBSCalorimeter::FindClusters()
 	  NSize--;
 	}
       }
+
+      // Adding total cluster energy threshold
+      if ( (cluster->GetE())<fEmin_clusTotal ) fClusters.pop_back();
 
     } else break;
   }

--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -137,6 +137,7 @@ protected:
   std::vector<SBSCalorimeterCluster*> fClusters; // Cluster
 
   Double_t fEmin_clusSeed; //< Minimum energy to be the seed of a cluster
+  Double_t fEmin_clusTotal; //< Total energy threshold of a cluster
 
   Double_t    fEmin;         //< Minimum energy for a cluster center
   Double_t    fXmax_dis;         //< maximum X distance from a cluster center


### PR DESCRIPTION
…e use for HCAL: sbs.hcal.emin_clTotal = 0.5 #GeV, NOTE: This only sets a threshold on only Shower cluster energy, doesn't affect PreShower cluster energy at all.