### PR TITLE
Cleanup ClearEvent

### DIFF
--- a/MPDModule.cxx
+++ b/MPDModule.cxx
@@ -49,7 +49,7 @@ namespace Decoder {
     DoRegister( ModuleType( "Decoder::MPDModule" , 3561 ));
 
   MPDModule::MPDModule(Int_t crate, Int_t slot) : VmeModule(crate, slot) {
-    fDebugFile=0;
+    fDebugFile=nullptr;
     Init(); //Should this be called here? not clear...
     
   }
@@ -61,8 +61,8 @@ namespace Decoder {
   void MPDModule::Init() { 
     VmeModule::Init();
     //    Config(0,25,6,16,128); // should be called by the user (but how?)
-    fDebugFile=0;
-    Clear("");
+    fDebugFile=nullptr;
+    Clear();
     //    fName = "MPD Module (INFN MPD for GEM and more), use Config to dynamic config";
     fName = "MPD Module";
 

--- a/MPDModule.cxx
+++ b/MPDModule.cxx
@@ -817,7 +817,8 @@ namespace Decoder {
     return 0;
   }
   
-  void MPDModule::Clear(const Option_t *opt) {
+  void MPDModule::Clear(const Option_t* opt) {
+    VmeModule::Clear(opt);
     // fNumHits = 0;
     // for (Int_t i=0; i<fNumChan*fNumSample*fNumADC; i++) fData[i]=0;
     // for (Int_t i=0; i<fNumADC*fNumSample; i++) { 

--- a/MPDModule.h
+++ b/MPDModule.h
@@ -36,7 +36,7 @@ namespace Decoder {
 
   public:
 
-    MPDModule() {};
+    MPDModule() = default;
     MPDModule(Int_t crate, Int_t slot);
     virtual ~MPDModule();
 

--- a/MPDModule.h
+++ b/MPDModule.h
@@ -46,7 +46,7 @@ namespace Decoder {
     virtual UInt_t GetData( UInt_t adc, UInt_t sample, UInt_t chan) const;
     virtual void Init();
     virtual void Init( const char *configstr );
-    virtual void Clear(const Option_t *opt);
+    virtual void Clear(const Option_t *opt="");
     virtual Int_t Decode(const UInt_t *p); // { return 0; };
     
     /*

--- a/MPDModuleVMEv4.cxx
+++ b/MPDModuleVMEv4.cxx
@@ -67,7 +67,7 @@ namespace Decoder {
     fNumSample = 6;
     
     fDebugFile=0;
-    Clear("");
+    Clear();
     //    fName = "MPD Module (INFN MPD for GEM and more), use Config to dynamic config";
     fName = "MPD Module";
   }
@@ -624,6 +624,7 @@ namespace Decoder {
   }
   
   void MPDModuleVMEv4::Clear(const Option_t *opt) {
+    VmeModule::Clear(opt);
     // fNumHits = 0;
     // for (Int_t i=0; i<fNumChan*fNumSample*fNumADC; i++) fData[i]=0;
     // for (Int_t i=0; i<fNumADC*fNumSample; i++) { 

--- a/MPDModuleVMEv4.h
+++ b/MPDModuleVMEv4.h
@@ -36,7 +36,7 @@ namespace Decoder {
 
   public:
 
-    MPDModuleVMEv4() {};
+    MPDModuleVMEv4() = default;
     MPDModuleVMEv4(Int_t crate, Int_t slot);
     virtual ~MPDModuleVMEv4();
 

--- a/MPDModuleVMEv4.h
+++ b/MPDModuleVMEv4.h
@@ -46,7 +46,7 @@ namespace Decoder {
 
     virtual UInt_t GetData( UInt_t adc, UInt_t sample, UInt_t chan) const;
     virtual void Init();
-    virtual void Clear(const Option_t *opt);
+    virtual void Clear(const Option_t *opt="");
     virtual Int_t Decode(const UInt_t *p); // { return 0; };
     
     /*

--- a/SBSAdcHit.cxx
+++ b/SBSAdcHit.cxx
@@ -68,7 +68,7 @@ void SBSAdcHit::Clear(Option_t *) {
   // clear the data inside SBSAdcHit, so it does not have to be deleted each
   // time
 
-  fPMT = 0;
+  fPMT = nullptr;
   fRawAmpl = fAmplPedCor = fSide = 0;
   fBarNum = -1;
   fAmpl = 0;

--- a/SBSAdcHit.cxx
+++ b/SBSAdcHit.cxx
@@ -64,7 +64,7 @@ Int_t SBSAdcHit::Compare(const TObject *obj) const {
 }
 
 //_____________________________________________________________________________
-void SBSAdcHit::Clear(Option_t *s) {
+void SBSAdcHit::Clear(Option_t *) {
   // clear the data inside SBSAdcHit, so it does not have to be deleted each
   // time
 

--- a/SBSAdcHit.h
+++ b/SBSAdcHit.h
@@ -14,8 +14,10 @@
 class SBSAdcHit : public TObject {
   
  public:
-  SBSAdcHit(SBSScintPMT* pmt=NULL, Int_t rawampl=0); 
-  virtual ~SBSAdcHit() {}
+  explicit SBSAdcHit(SBSScintPMT* pmt=nullptr, Int_t rawampl=0);
+  virtual ~SBSAdcHit() = default;
+
+  virtual void Clear(Option_t *s="");
 
   SBSScintPMT* GetPMT() const { return (SBSScintPMT*)fPMT.GetObject(); }
   Int_t GetRawAmpl() const {return fRawAmpl;}
@@ -32,7 +34,6 @@ class SBSAdcHit : public TObject {
   Bool_t IsSortable() const { return kTRUE; }
 
   Int_t  Compare(const TObject* obj) const;
-  void Clear(Option_t *s="");
 
  protected:
 

--- a/SBSBBShower.cxx
+++ b/SBSBBShower.cxx
@@ -151,8 +151,8 @@ SBSBBShower::~SBSBBShower()
 }
 
 void SBSBBShower::LoadMCHitAt( Double_t x, Double_t y, Double_t E )
-{  
-  ClearEvent();
+{
+  Clear();
   SBSCalorimeterCluster *cluster = new SBSCalorimeterCluster(fNclublk);
   cluster->SetE(E);
   cluster->SetX(x);
@@ -217,9 +217,9 @@ void SBSBBShower::SetSearchRegion(int rowmin, int rowmax, int colmin, int colmax
   fMultClus = false;
 }
 
-void SBSBBShower::ClearEvent()
+void SBSBBShower::Clear( Option_t* opt )
 {
-  SBSCalorimeter::ClearEvent();
+  SBSCalorimeter::Clear(opt);
 
   fEres = fXres = fYres = 0.0;
   fE_cl_res.clear();

--- a/SBSBBShower.h
+++ b/SBSBBShower.h
@@ -26,21 +26,21 @@ public:
   virtual void   MakeCluster(Int_t nblk_size);
   virtual void   AddToCluster(Int_t nc,SBSElement* blk);
   virtual void MakeMainCluster();
-  virtual void ClearEvent();
+  virtual void Clear( Option_t* opt="" );
 
   Int_t GetRowMax() {return GetRow();}
   Int_t GetColMax() {return GetCol();}
 
   
-  Double_t EresMax() {return fEres;}
-  Double_t XresMax() {return fXres;}
-  Double_t YresMax() {return fYres;}
+  Double_t EresMax() const {return fEres;}
+  Double_t XresMax() const {return fXres;}
+  Double_t YresMax() const {return fYres;}
   
-  Double_t Eres(int i) {return fE_cl_res[i];}
-  Double_t Xres(int i) {return fX_cl_res[i];}
-  Double_t Yres(int i) {return fY_cl_res[i];}
+  Double_t Eres(int i) const {return fE_cl_res[i];}
+  Double_t Xres(int i) const {return fX_cl_res[i];}
+  Double_t Yres(int i) const {return fY_cl_res[i];}
 
-    SBSElement* GetElement(UInt_t i);
+  SBSElement* GetElement(UInt_t i);
     
   //two methods to set search region.
   void SetSearchRegion(int rowmin, int rowmax, int colmin, int colmax);

--- a/SBSBBShower.h
+++ b/SBSBBShower.h
@@ -13,8 +13,8 @@
 
 class SBSBBShower : public SBSCalorimeter {
 public:
-  SBSBBShower( const char* name, const char* description = "",
-      THaApparatus* a = NULL);
+  explicit SBSBBShower( const char* name, const char* description = "",
+                        THaApparatus* a = nullptr);
   virtual ~SBSBBShower();
 
   // Standard apparatus re-implemented functions

--- a/SBSBBTotalShower.cxx
+++ b/SBSBBTotalShower.cxx
@@ -151,15 +151,16 @@ exit:
 //_____________________________________________________________________________
 Int_t SBSBBTotalShower::Decode( const THaEvData& evdata )
 {
-  ClearEvent();
   fShower->Decode(evdata);
   fPreShower->Decode(evdata);
   return 0;
 }
 //_____________________________________________________________________________
-void SBSBBTotalShower::ClearEvent() {
-  fShower->ClearEvent();
-  fPreShower->ClearEvent();
+void SBSBBTotalShower::Clear( Option_t* opt )
+{
+  SBSCalorimeter::Clear(opt);
+  fShower->Clear(opt);
+  fPreShower->Clear(opt);
   fSHclusPSclusIDmap.clear();
 }
 
@@ -355,7 +356,7 @@ void SBSBBTotalShower::SetApparatus( THaApparatus* app )
 
 void SBSBBTotalShower::LoadMCHitAt( Double_t x, Double_t y, Double_t E )
 {
-    ClearEvent();
+  Clear();
     /*
   fNclust = 0;
     fE = double(E);

--- a/SBSBBTotalShower.cxx
+++ b/SBSBBTotalShower.cxx
@@ -30,8 +30,8 @@ ClassImp(SBSBBTotalShower)
 //_____________________________________________________________________________
 SBSBBTotalShower::SBSBBTotalShower( const char* name, const char* description,
                                    THaApparatus* apparatus ) :
-SBSCalorimeter(name,description,apparatus), 
-  fShower(NULL), fPreShower(NULL), fMaxDx(0.4), fMaxDy(0.4)
+  SBSCalorimeter(name,description,apparatus),
+  fShower(nullptr), fPreShower(nullptr), fMaxDx(0.4), fMaxDy(0.4)
 //fE(0.0), fX(0.0), fY(0.0)//, fID(NULL)
 {
     // Constructor. With this method, the subdetectors are created using
@@ -52,7 +52,7 @@ SBSBBTotalShower::SBSBBTotalShower( const char* name,
                                    const char* description,
                                    THaApparatus* apparatus ) :
   SBSCalorimeter(name,description,apparatus),
-  fShower(NULL), fPreShower(NULL),fMaxDx(0.4), fMaxDy(0.4)
+  fShower(nullptr), fPreShower(nullptr),fMaxDx(0.4), fMaxDy(0.4)
   //fE(0.0), fX(0.0), fY(0.0)
 {
     // Constructor. With this method, the subdetectors are created using
@@ -146,7 +146,6 @@ void SBSBBTotalShower::Setup( const char* name,
 exit:
     delete [] subname;
     delete [] desc;
-    return;
 }
 //_____________________________________________________________________________
 Int_t SBSBBTotalShower::Decode( const THaEvData& evdata )
@@ -349,7 +348,6 @@ void SBSBBTotalShower::SetApparatus( THaApparatus* app )
     SBSCalorimeter::SetApparatus( app );
     fShower->SetApparatus( app );
     fPreShower->SetApparatus( app );
-    return;
 }
 
 //_____________________________________________________________________________

--- a/SBSBBTotalShower.h
+++ b/SBSBBTotalShower.h
@@ -41,7 +41,8 @@ class SBSBBTotalShower : public SBSCalorimeter { //THaPidDetector {
 		    const char* preshower_name, const char* description = "",
 		    THaApparatus* a = NULL );
   virtual ~SBSBBTotalShower();
-  
+
+  virtual void       Clear( Option_t* opt="" );
   virtual Int_t      Decode( const THaEvData& );
   virtual Int_t      CoarseProcess( TClonesArray& tracks );
   virtual Int_t      FineProcess( TClonesArray& tracks );
@@ -82,7 +83,6 @@ class SBSBBTotalShower : public SBSCalorimeter { //THaPidDetector {
   //key = SH cluster ID, value = PS cluster ID;
   std::vector<int> fSHclusPSclusIDmap;
   
-  void           ClearEvent();
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );
   virtual Bool_t  IsPid()      { return true; }

--- a/SBSBBTotalShower.h
+++ b/SBSBBTotalShower.h
@@ -39,7 +39,7 @@ class SBSBBTotalShower : public SBSCalorimeter { //THaPidDetector {
 		    THaApparatus* a = nullptr );
   SBSBBTotalShower( const char* name, const char* shower_name,
 		    const char* preshower_name, const char* description = "",
-		    THaApparatus* a = NULL );
+		    THaApparatus* a = nullptr );
   virtual ~SBSBBTotalShower();
 
   virtual void       Clear( Option_t* opt="" );

--- a/SBSBBTotalShower.h
+++ b/SBSBBTotalShower.h
@@ -35,8 +35,8 @@ class SBSCalorimeter;
 class SBSBBTotalShower : public SBSCalorimeter { //THaPidDetector {
   
  public:
-  SBSBBTotalShower( const char* name, const char* description = "",
-		    THaApparatus* a = NULL );
+  explicit SBSBBTotalShower( const char* name, const char* description = "",
+		    THaApparatus* a = nullptr );
   SBSBBTotalShower( const char* name, const char* shower_name,
 		    const char* preshower_name, const char* description = "",
 		    THaApparatus* a = NULL );

--- a/SBSBPM.cxx
+++ b/SBSBPM.cxx
@@ -111,9 +111,10 @@ Int_t SBSBPM::DefineVariables( EMode mode )
 
 }
 //_____________________________________________________________________________
-void SBSBPM::Clear( Option_t* )
+void SBSBPM::Clear( Option_t* opt )
 {
   // Reset per-event data.
+  THaBeamDet::Clear(opt);
   fPosition.SetXYZ(0.,0.,-10000.);
   fDirection.SetXYZ(0.,0.,1.);
   fNfired=0;
@@ -125,8 +126,6 @@ void SBSBPM::Clear( Option_t* )
 //_____________________________________________________________________________
 Int_t SBSBPM::Decode( const THaEvData& evdata )
 {
-
-  // clears the event structure
   // loops over all modules defined in the detector map
   // copies raw data into local variables
   // performs pedestal subtraction

--- a/SBSBPM.h
+++ b/SBSBPM.h
@@ -30,8 +30,8 @@ using namespace std;
 class SBSBPM : public THaBeamDet {
 
 public:
-	SBSBPM( const char* name, const char* description = "",
-			THaApparatus* a = NULL );
+	explicit SBSBPM( const char* name, const char* description = "",
+                         THaApparatus* a = nullptr );
 	virtual ~SBSBPM();
 
 	virtual void       Clear( Option_t* ="" );

--- a/SBSBigBite.h
+++ b/SBSBigBite.h
@@ -13,7 +13,7 @@ public:
   SBSBigBite( const char *name, const char *description );
   virtual ~SBSBigBite();
     
-  virtual void             Clear( Option_t* opt="");
+  virtual void  Clear( Option_t* opt="");
   
   virtual Int_t	CoarseReconstruct();
   virtual Int_t	CoarseTrack();

--- a/SBSCDet.cxx
+++ b/SBSCDet.cxx
@@ -72,7 +72,7 @@ ClassImp(SBSCDet)
 
 //____________________________________________________________________________
 SBSCDet::SBSCDet( const char* name, const char* description,
-								   THaApparatus* apparatus) :
+                  THaApparatus* apparatus) :
 THaNonTrackingDetector(name,description,apparatus)
 {
 

--- a/SBSCDet.cxx
+++ b/SBSCDet.cxx
@@ -1573,11 +1573,11 @@ void SBSCDet::DeleteArrays()
 }
 
 //_____________________________________________________________________________
-inline 
-void SBSCDet::ClearEvent()
+void SBSCDet::Clear( Option_t* opt )
 {
 	// Reset per-event data.
 
+  THaNonTrackingDetector::Clear(opt);
 #if 0
 	const char cBig = 198;
 
@@ -1692,8 +1692,6 @@ Int_t SBSCDet::Decode( const THaEvData& evdata )
 	// Decode scintillator data, correct TDC times and ADC amplitudes, and copy
 	// the data to the local data members.
 	static const char *here="Decode()";
-
-	ClearEvent();
 
 	fEventCount++;
 

--- a/SBSCDet.h
+++ b/SBSCDet.h
@@ -85,6 +85,7 @@ public:
 	virtual ~SBSCDet();
 	virtual Int_t        InitOutput( THaOutput* output );
 
+        virtual void       Clear( Option_t* opt="" );
 	virtual Int_t      Decode( const THaEvData& );
 	virtual Int_t      CoarseProcess( TClonesArray& tracks );
 	virtual Int_t      FineProcess( TClonesArray& tracks );
@@ -265,7 +266,6 @@ protected:
 	Bool_t  fTooManyErrRefCh;       //flag whether there are too much error reference
 
 
-	void           ClearEvent();
 	void           DeleteArrays();
 	virtual Int_t  ReadDatabase( const TDatime& date );
 	virtual Int_t  DefineVariables( EMode mode = kDefine );

--- a/SBSCHAnalyzer.cxx
+++ b/SBSCHAnalyzer.cxx
@@ -69,17 +69,17 @@ Int_t SBSCHAnalyzer::DefineVariables( EMode mode )
 }
 
 /*
- * ClearEvent()
+ * Clear()
  * called at the end of every event
  */
-void SBSCHAnalyzer::ClearEvent()
+void SBSCHAnalyzer::Clear( Option_t* opt )
 {
   // If we defined any new variables that we need to clear prior to the next event
   // clear them here:
   // fExample = 0.0;
 
-  // Make sure to call parent class's ClearEvent() also!
-  SBSGenericDetector::ClearEvent();
+  // Make sure to call parent class's Clear() also!
+  SBSGenericDetector::Clear(opt);
 }
 
 /*

--- a/SBSCHAnalyzer.h
+++ b/SBSCHAnalyzer.h
@@ -24,7 +24,7 @@ public:
   virtual Int_t   CoarseProcess( TClonesArray& tracks );
   virtual Int_t   FineProcess( TClonesArray& tracks );
   virtual Int_t   FindGoodHit(SBSElement *element);
-  virtual void ClearEvent();
+  virtual void    Clear( Option_t* opt="" );
 
   ClassDef(SBSCHAnalyzer,5)  // Describes scintillator plane with F1TDC as a detector
 };

--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -60,8 +60,6 @@ SBSCalorimeter::~SBSCalorimeter()
     RemoveVariables();
   //  if( fIsInit ) {
   //  }
-
-  ClearEvent();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -277,14 +275,15 @@ Int_t SBSCalorimeter::DefineVariables( EMode mode )
 }
 
 //_____________________________________________________________________________
-void SBSCalorimeter::ClearEvent()
+void SBSCalorimeter::Clear( Option_t* opt )
 {
-  SBSGenericDetector::ClearEvent();
+  SBSGenericDetector::Clear(opt);
   ClearOutputVariables();
   DeleteContainer(fClusters);
   fGoodBlocks.clear();
   fBlockSet.clear();
 }
+
 //_____________________________________________________________________________
 Int_t SBSCalorimeter::MakeGoodBlocks()
 {

--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -74,8 +74,8 @@ typedef std::vector<SBSBlockSet> SBSBlockSetList;
 class SBSCalorimeter : public SBSGenericDetector {
 
 public:
-  SBSCalorimeter( const char* name, const char* description = "",
-      THaApparatus* a = NULL);
+  explicit SBSCalorimeter( const char* name, const char* description = "",
+      THaApparatus* a = nullptr);
   virtual ~SBSCalorimeter();
 
   virtual void Clear( Option_t* opt="" );

--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -78,8 +78,7 @@ public:
       THaApparatus* a = NULL);
   virtual ~SBSCalorimeter();
 
-  virtual void ClearEvent();
-  virtual void ClearOutputVariables();
+  virtual void Clear( Option_t* opt="" );
   virtual Int_t MakeGoodBlocks();
   virtual Int_t FindClusters();
 
@@ -157,6 +156,9 @@ protected:
 
   Double_t GetVVal(std::vector<Double_t> &v, UInt_t i = 0 );
   Int_t GetVVal(std::vector<Int_t> &v, UInt_t i = 0 );
+
+private:
+  void ClearOutputVariables();
 
   ClassDef(SBSCalorimeter,0)     //Generic shower detector class
 };

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -101,7 +101,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
 }
 
 //_____________________________________________________________
-void SBSCalorimeterCluster::ClearEvent() {
+void SBSCalorimeterCluster::Clear( Option_t* opt ) {
     fMult=0;fX=fY=fE=0.;
     fEblk=0;
     fAtime=0;

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -48,7 +48,7 @@ public:
     SBSElement* GetElement(UInt_t i);
     std::vector<SBSElement*>& GetElements() {return fElements;}
 
-    Int_t GetSize() {return fMult;}
+    Int_t GetSize() const {return fMult;}
 
     void AddElement(SBSElement* block);
 

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -52,7 +52,7 @@ public:
 
     void AddElement(SBSElement* block);
 
-    void ClearEvent();
+    virtual void Clear( Option_t* opt="" );
 
 private:
 

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -15,7 +15,7 @@ class SBSCalorimeterCluster : public TObject {
 public:
 
     SBSCalorimeterCluster();
-    SBSCalorimeterCluster(Int_t nmaxblk);
+    explicit SBSCalorimeterCluster(Int_t nmaxblk);
     SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block);
     virtual ~SBSCalorimeterCluster();
 

--- a/SBSCherenkovDetector.cxx
+++ b/SBSCherenkovDetector.cxx
@@ -201,8 +201,6 @@ Int_t SBSCherenkovDetector::Decode( const THaEvData& evdata )
   }
   if( !fIsInit ) return -255;
   if( !evdata.IsPhysicsTrigger() ) return -1;
-
-  Clear();
   
   if( fDoBench ) fBench->Begin("Decode");
   

--- a/SBSCherenkovDetector.cxx
+++ b/SBSCherenkovDetector.cxx
@@ -241,7 +241,7 @@ Int_t SBSCherenkovDetector::CoarseProcess( TClonesArray& tracks )
       
       x = (fElements[fGood.TDCelemID[k]])->GetX();
       y = (fElements[fGood.TDCelemID[k]])->GetY();
-      if(k<fAmpToTCoeff.size()){
+      if(k<(int)fAmpToTCoeff.size()){
 	amp = fGood.t_ToT[k]*fAmpToTCoeff[k];
       }else{// we should be guaranteed that the array has at least one element
 	amp = fGood.t_ToT[k]*fAmpToTCoeff[0];
@@ -276,7 +276,6 @@ void SBSCherenkovDetector::DeleteClusters()
   if(fDebug)cout << "Clear Clusters" << endl;
   fClusters->Clear("C");
   //fResolvedClusters->Clear("C");
-  return;
 }
 
 //_____________________________________________________________________________
@@ -294,7 +293,6 @@ void SBSCherenkovDetector::PrintBenchmarks() const
   
   //cout << endl << "Breakdown of time spent in FineProcess:" << endl;
   
-  return;
 }
 
 ClassImp(SBSCherenkovDetector)

--- a/SBSCherenkovDetector.h
+++ b/SBSCherenkovDetector.h
@@ -14,7 +14,7 @@
 #include "SBSCherenkov_ClusterList.h"
 #include "TBits.h"
 #include "TClonesArray.h"
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 
 class THaTrack;

--- a/SBSCherenkovDetector.h
+++ b/SBSCherenkovDetector.h
@@ -24,8 +24,8 @@ class SBSCherenkovDetector : public SBSGenericDetector {
   
 public:
 
-  SBSCherenkovDetector( const char* name, const char* description="", 
-	   THaApparatus* apparatus=NULL );
+  explicit SBSCherenkovDetector( const char* name, const char* description="",
+	   THaApparatus* apparatus=nullptr );
   virtual ~SBSCherenkovDetector();
   
   virtual void         Clear( Option_t* opt="" );

--- a/SBSData.h
+++ b/SBSData.h
@@ -199,26 +199,26 @@ namespace SBSData {
       virtual ~Waveform() {};
 
       // Getters
-      Double_t GetPed()  const { return fSamples.ped; }
-      Double_t GetGain() const { return fSamples.cal; }
-      Double_t GetThres() const { return fSamples.thres; }
-      Double_t GetChanTomV() const { return fSamples.ChanTomV; }
-      Double_t GetAmpCal() const { return fSamples.acal; }
-      Double_t GetTrigCal() const { return fSamples.trigcal; }
-      Double_t GetTimeOffset() const { return fSamples.timeoffset; }
-      UInt_t GetFixThresBin() const { return fSamples.FixThresBin; }
-      UInt_t GetNSB() const { return fSamples.NSB; }
-      UInt_t GetNSA() const { return fSamples.NSA; }
-      UInt_t GetNPedBin() const { return fSamples.NPedBin; }
-      Double_t GetGoodTimeCut()              const { return fSamples.GoodTimeCut;}
-      Int_t GetGoodHitIndex()            const { return fSamples.good_hit; }
+      Double_t GetPed()         const { return fSamples.ped; }
+      Double_t GetGain()        const { return fSamples.cal; }
+      Double_t GetThres()       const { return fSamples.thres; }
+      Double_t GetChanTomV()    const { return fSamples.ChanTomV; }
+      Double_t GetAmpCal()      const { return fSamples.acal; }
+      Double_t GetTrigCal()     const { return fSamples.trigcal; }
+      Double_t GetTimeOffset()  const { return fSamples.timeoffset; }
+      UInt_t GetFixThresBin()   const { return fSamples.FixThresBin; }
+      UInt_t GetNSB()           const { return fSamples.NSB; }
+      UInt_t GetNSA()           const { return fSamples.NSA; }
+      UInt_t GetNPedBin()       const { return fSamples.NPedBin; }
+      Double_t GetGoodTimeCut() const { return fSamples.GoodTimeCut;}
+      Int_t GetGoodHitIndex()   const { return fSamples.good_hit; }
       std::vector<Double_t>& GetDataRaw() { return fSamples.samples_raw; }
       std::vector<Double_t>& GetData() { return fSamples.samples; }
-      PulseADCData GetPulse() { return fSamples.pulse; }
-      SingleData GetIntegral()   { return fSamples.pulse.integral; }
-      SingleData GetTime()   { return fSamples.pulse.time; }
-      SingleData GetAmplitude()   { return fSamples.pulse.amplitude; }
-      Double_t GetTimeData()         const { return fSamples.pulse.time.val; }
+      PulseADCData GetPulse()   const { return fSamples.pulse; }
+      SingleData GetIntegral()  const { return fSamples.pulse.integral; }
+      SingleData GetTime()      const { return fSamples.pulse.time; }
+      SingleData GetAmplitude() const { return fSamples.pulse.amplitude; }
+      Double_t GetTimeData()    const { return fSamples.pulse.time.val; }
 
       // Setters
       void SetValTime(Double_t var)  { fSamples.pulse.time.val = var; }
@@ -236,7 +236,7 @@ namespace SBSData {
       virtual void Process(std::vector<Double_t> &var);
 
       // Do we have samples data for this event?
-      Bool_t HasData() { return fHasData; }
+      Bool_t HasData() const { return fHasData; }
 
       // Clear event
       virtual void Clear();

--- a/SBSData.h
+++ b/SBSData.h
@@ -195,8 +195,9 @@ namespace SBSData {
   // Samples (e.g. ADC Waveform data)
   class Waveform {
     public:
-      Waveform(Double_t ped = 0.0, Double_t gain = 1.0, Double_t ChanTomV = 0.48828,Double_t GoodTimeCut = 1.0, Double_t tcal = 4.0);
-      virtual ~Waveform() {};
+      explicit Waveform( Double_t ped = 0.0, Double_t gain = 1.0, Double_t ChanTomV = 0.48828,
+                       Double_t GoodTimeCut = 1.0, Double_t tcal = 4.0 );
+      virtual ~Waveform() = default;;
 
       // Getters
       Double_t GetPed()         const { return fSamples.ped; }

--- a/SBSDecodeF1TDCModule.cxx
+++ b/SBSDecodeF1TDCModule.cxx
@@ -52,14 +52,14 @@ SBSDecodeF1TDCModule::~SBSDecodeF1TDCModule() = default;
 void SBSDecodeF1TDCModule::CommonInit() {
   //fTdcData = new Int_t[NTDCCHAN*MAXHIT];
   //fNumHits = new Int_t[NTDCCHAN*MAXHIT];
-  fDebugFile=0;
+  fDebugFile=nullptr;
   //fDebugFile = new std::ofstream("hcal_tdc_test_decoder.log");
   Clear();
   IsInit = kTRUE;
   nF1=0;
   F1slots.resize(50);
-  for(size_t i = 0; i < F1slots.size(); i++) {
-    F1slots[i] = 0;
+  for(int & F1slot : F1slots) {
+    F1slot = 0;
   }
   //F1slots = new Int_t[50];
   //memset(F1slots, 0, 50*sizeof(Int_t));

--- a/SBSDecodeF1TDCModule.h
+++ b/SBSDecodeF1TDCModule.h
@@ -16,7 +16,7 @@ class SBSDecodeF1TDCModule : public VmeModule {
 
 public:
 
-   SBSDecodeF1TDCModule() {};
+   SBSDecodeF1TDCModule() {}
    SBSDecodeF1TDCModule(Int_t crate, Int_t slot);
    virtual ~SBSDecodeF1TDCModule();
 

--- a/SBSElement.cxx
+++ b/SBSElement.cxx
@@ -44,7 +44,7 @@ Bool_t SBSElement::HasADCData()
 
 ///////////////////////////////////////////////////////////////////////////////
 // Clear event from generic Element (with no data)
-void SBSElement::ClearEvent()
+void SBSElement::Clear( Option_t* opt )
 {
   fE = 0; // Reset calibrated energy for given event
   fStat = 0; // Reset status to 0, unseen

--- a/SBSElement.h
+++ b/SBSElement.h
@@ -54,7 +54,7 @@ public:
   void SetWaveform(Double_t ped, Double_t gain,Double_t ChanToMv,Double_t adc_timecut);
 
   // Sub-classes may want a more comprehensive clear
-  virtual void ClearEvent();
+  virtual void Clear( Option_t* opt="" );
 
 
   // Check if this block has any data

--- a/SBSGEMModule.cxx
+++ b/SBSGEMModule.cxx
@@ -945,8 +945,8 @@ void SBSGEMModule::Clear( Option_t* opt){ //we will want to clear out many more 
   // fTmean.clear();
   // fTsigma.clear();
   // fTcorr.clear();
-  
-  return;
+
+  THaSubDetector::Clear(opt);
 }
 
 Int_t   SBSGEMModule::Decode( const THaEvData& evdata ){

--- a/SBSGEMModule.cxx
+++ b/SBSGEMModule.cxx
@@ -186,11 +186,9 @@ SBSGEMModule::~SBSGEMModule() {
   //     delete fStrip;
   //     fStrip = NULL;
   // }
-  if( fStripTimeFunc ){
-    delete fStripTimeFunc;
-  }
 
-  return;
+  delete fStripTimeFunc;
+
 }
 
 Int_t SBSGEMModule::ReadDatabase( const TDatime& date ){

--- a/SBSGEMModule.h
+++ b/SBSGEMModule.h
@@ -124,8 +124,8 @@ struct sbsgemcluster_t {  //1D clusters;
 class SBSGEMModule : public THaSubDetector {
  public:
 
-  SBSGEMModule( const char *name, const char *description = "",
-		THaDetectorBase* parent = 0 );
+  explicit SBSGEMModule( const char *name, const char *description = "",
+                         THaDetectorBase* parent = nullptr );
 
   virtual ~SBSGEMModule();
 

--- a/SBSGEMPlane.cxx
+++ b/SBSGEMPlane.cxx
@@ -246,7 +246,7 @@ void    SBSGEMPlane::Clear( Option_t* opt){
   fadc_4.clear();
   fadc_5.clear();
   
-  return;
+  THaSubDetector::Clear(opt);
 }
 
 Int_t   SBSGEMPlane::Decode( const THaEvData& evdata ){

--- a/SBSGEMSpectrometerTracker.cxx
+++ b/SBSGEMSpectrometerTracker.cxx
@@ -291,6 +291,7 @@ Int_t SBSGEMSpectrometerTracker::Begin( THaRunBase* run ) {
 }
 
 void SBSGEMSpectrometerTracker::Clear( Option_t *opt ){
+  THaTrackingDetector::Clear(opt);
   SBSGEMTrackerBase::Clear();
 
   for( auto& module: fModules ) {

--- a/SBSGEMSpectrometerTracker.h
+++ b/SBSGEMSpectrometerTracker.h
@@ -15,8 +15,8 @@ class TClonesArray;
 
 class SBSGEMSpectrometerTracker : public THaTrackingDetector, public SBSGEMTrackerBase {
  public:
-  SBSGEMSpectrometerTracker( const char *name, const char *description = "",
-	       THaApparatus *app = 0 );
+  explicit SBSGEMSpectrometerTracker( const char *name, const char *description = "",
+                                      THaApparatus *app = nullptr );
 
   virtual ~SBSGEMSpectrometerTracker();
 

--- a/SBSGEMStand.cxx
+++ b/SBSGEMStand.cxx
@@ -72,9 +72,10 @@ Int_t SBSGEMStand::ReadDatabase( const TDatime& date ){
         {0}
     };
 
-    Int_t status = kInitError;
     err = LoadDB( file, date, request, fPrefix );
     fclose(file);
+    if(err)
+      return err;
 
     //vsplit is a Podd function that "tokenizes" a string into a vector<string> by whitespace:
     std::vector<std::string> planes = vsplit(planeconfig);
@@ -82,14 +83,9 @@ Int_t SBSGEMStand::ReadDatabase( const TDatime& date ){
             Error("", "[SBSGEMStand::ReadDatabase] No planes defined");
     }
 
-    for (std::vector<std::string>::iterator it = planes.begin() ; it != planes.end(); ++it){
-      fPlanes.push_back(new SBSGEMPlane( (*it).c_str(), (*it).c_str(), this, fIsMC));
+    for (const auto& name : planes ) {
+      fPlanes.push_back(new SBSGEMPlane( name.c_str(), name.c_str(), this, fIsMC));
     }
-
-    status = kOK;
-
-    if( status != kOK )
-        return status;
 
     fIsInit = kTRUE;
     
@@ -118,8 +114,8 @@ Int_t SBSGEMStand::Decode(const THaEvData& evdata ){
   //return 0;
   //std::cout << "[SBSGEMStand::Decode]" << std::endl;
 
-    for (std::vector<SBSGEMPlane *>::iterator it = fPlanes.begin() ; it != fPlanes.end(); ++it){
-      (*it)->Decode(evdata);
+    for (auto* plane : fPlanes ) {
+      plane->Decode(evdata);
     }
 
     return 0;
@@ -127,8 +123,8 @@ Int_t SBSGEMStand::Decode(const THaEvData& evdata ){
 
 
 Int_t SBSGEMStand::End( THaRunBase* run ){
-    for (std::vector<SBSGEMPlane *>::iterator it = fPlanes.begin() ; it != fPlanes.end(); ++it){
-        (*it)->End(run);
+    for (auto* plane : fPlanes ) {
+        plane->End(run);
     }
 
 
@@ -143,8 +139,8 @@ void SBSGEMStand::Print(const Option_t* opt) const {
         (*it)->Print(opt);
     }
     */
-    for( unsigned int i = 0; i < fPlanes.size(); i++ ){
-        fPlanes[i]->Print(opt);
+    for( auto* plane : fPlanes.size() ){
+        plane->Print(opt);
     }
 
     return;
@@ -153,8 +149,8 @@ void SBSGEMStand::Print(const Option_t* opt) const {
 
 void SBSGEMStand::SetDebug( Int_t level ){
       THaTrackingDetector::SetDebug( level );
-    for (std::vector<SBSGEMPlane *>::iterator it = fPlanes.begin() ; it != fPlanes.end(); ++it){
-        (*it)->SetDebug(level);
+    for (auto* plane : fPlanes ) {
+        plane->SetDebug(level);
     }
 
     return;

--- a/SBSGEMStand.cxx
+++ b/SBSGEMStand.cxx
@@ -106,8 +106,9 @@ Int_t SBSGEMStand::Begin( THaRunBase* run ){
 }
 
 void SBSGEMStand::Clear( Option_t *opt ){
-    for (std::vector<SBSGEMPlane *>::iterator it = fPlanes.begin() ; it != fPlanes.end(); ++it){
-        (*it)->Clear(opt);
+  THaTrackingDetector::Clear(opt);
+  for (auto* plane : fPlanes ){
+        plane->Clear(opt);
     }
 
     return;

--- a/SBSGRINCH.cxx
+++ b/SBSGRINCH.cxx
@@ -152,7 +152,7 @@ Int_t SBSGRINCH::CoarseProcess( TClonesArray& tracks )
   // add clustering here: hits have been filtered by SBSCherenkovDetector::CoarseProcess()
   // clustering ought to be coded in function "FindClusters" below
   
-  int err = FindClusters();
+  /*int err = */FindClusters();
   
   if( fDoBench ) fBench->Stop("CoarseProcess");
   if(fDebug)cout << "End Coarse Process" << endl;

--- a/SBSGRINCH.h
+++ b/SBSGRINCH.h
@@ -25,8 +25,8 @@ class SBSGRINCH : public SBSCherenkovDetector {
   
 public:
 
-  SBSGRINCH( const char* name, const char* description="", 
-	   THaApparatus* apparatus=NULL );
+  explicit SBSGRINCH( const char* name, const char* description="",
+	   THaApparatus* apparatus=nullptr );
   virtual ~SBSGRINCH();
   
   virtual void         Clear( Option_t* opt="" );

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -1016,8 +1016,6 @@ Int_t SBSGenericDetector::Decode( const THaEvData& evdata )
 {
   // Decode data
 
-  // Clear last event
-  ClearEvent();
   //static const char* const here = "Decode()";
   // Loop over modules for the reference time
   SBSElement *blk = nullptr;
@@ -1201,29 +1199,11 @@ Int_t SBSGenericDetector::DecodeTDC( const THaEvData& evdata,
 }
 
 //_____________________________________________________________________________
-void SBSGenericDetector::ClearEvent()
+void SBSGenericDetector::Clear( Option_t* opt )
 {
   // Call our version in case sub-classes have re-implemented it
-  SBSGenericDetector::ClearOutputVariables();
-  fNhits = 0;
-  fNRefhits = 0;
-  fNGoodTDChits = 0;
-  fNGoodADChits = 0;
-  fCoarseProcessed = 0;
-  fFineProcessed = 0;
-  for( auto& element: fElements ) {
-    element->ClearEvent();
-  }
-  for( auto& refElement: fRefElements ) {
-    refElement->ClearEvent();
-  }
-}
-
-//_____________________________________________________________________________
-void SBSGenericDetector::Clear(Option_t* opt)
-{
-  // Call our version in case sub-classes have re-implemented it
-  SBSGenericDetector::ClearOutputVariables();
+  THaNonTrackingDetector::Clear(opt);
+  ClearOutputVariables();
   fNhits = 0;
   fNRefhits = 0;
   fNGoodTDChits = 0;
@@ -1231,10 +1211,10 @@ void SBSGenericDetector::Clear(Option_t* opt)
   fCoarseProcessed = false;
   fFineProcessed = false;
   for( auto& element: fElements ) {
-    element->ClearEvent();
+    element->Clear();
   }
   for( auto& refElement: fRefElements ) {
-    refElement->ClearEvent();
+    refElement->Clear();
   }
 }
 
@@ -1655,6 +1635,7 @@ Int_t SBSGenericDetector::FineProcess(TClonesArray&)//tracks)
   return 0;
 }
 
+//_____________________________________________________________________________
 void SBSGenericDetector::ClearOutputVariables()
 {
   fGood.clear();

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -127,8 +127,6 @@ public:
   virtual ~SBSGenericDetector();
 
   virtual void Clear( Option_t* opt="" );
-  virtual void ClearEvent();
-  virtual void ClearOutputVariables();
 
   void SetModeADC(SBSModeADC::Mode mode);
   void SetModeTDC(SBSModeTDC::Mode mode) { fModeTDC = mode; }
@@ -219,8 +217,12 @@ protected:
   // Flags for enabling and disabling various features
   Bool_t    fStoreRawHits; ///< Store the raw data in the root tree?
 
+private:
+  void ClearOutputVariables();
+
   ClassDef(SBSGenericDetector,0)     //Generic shower detector class
 };
+
 /*inline Int_t SBSGenericDetector::blkidx(Int_t row, Int_t col, Int_t layer)
 {
   return fNlayers*(fNcols[row]*row + col) + layer;

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -122,8 +122,8 @@ class SBSGenericDetector : public THaNonTrackingDetector {
   //class SBSGenericDetector : public THaShower {
 
 public:
-  SBSGenericDetector( const char* name, const char* description = "",
-      THaApparatus* a = NULL);
+  explicit SBSGenericDetector( const char* name, const char* description = "",
+                               THaApparatus* a = nullptr);
   virtual ~SBSGenericDetector();
 
   virtual void Clear( Option_t* opt="" );

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -155,8 +155,8 @@ public:
   virtual SBSElement* MakeElement(Double_t x, Double_t y, Double_t z, Int_t row,
       Int_t col, Int_t layer, Int_t id = 0);
   
-  Double_t SizeRow(){ return fSizeRow; };
-  Double_t SizeCol(){ return fSizeCol; };
+  Double_t SizeRow() const { return fSizeRow; };
+  Double_t SizeCol() const { return fSizeCol; };
   
 protected:
 

--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -114,11 +114,11 @@ Int_t SBSHCal::DefineVariables( EMode mode )
   return err;
 }
 
-void SBSHCal::ClearEvent()
+void SBSHCal::Clear( Option_t* opt )
 {
   fLEDBit = -1;
   fLEDCount = 0;
-  SBSCalorimeter::ClearEvent();
+  SBSCalorimeter::Clear(opt);
 }
 /*
  * Generic SBSHCal destructor

--- a/SBSHCal.h
+++ b/SBSHCal.h
@@ -20,7 +20,7 @@ public:
   virtual Int_t  Decode( const THaEvData& evdata );
   virtual Int_t  CoarseProcess(TClonesArray& tracks );
   virtual Int_t  DefineVariables( EMode mode = kDefine );
-  virtual void ClearEvent();
+  virtual void   Clear( Option_t* opt="" );
 
 protected:
   Bool_t fWithLED;

--- a/SBSHCal.h
+++ b/SBSHCal.h
@@ -13,8 +13,8 @@
 
 class SBSHCal : public SBSCalorimeter {
 public:
-  SBSHCal( const char* name, const char* description = "",
-      THaApparatus* a = NULL);
+  explicit SBSHCal( const char* name, const char* description = "",
+                    THaApparatus* a = nullptr);
   virtual ~SBSHCal();
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  Decode( const THaEvData& evdata );

--- a/SBSHCalLEDModule.cxx
+++ b/SBSHCalLEDModule.cxx
@@ -44,7 +44,7 @@ namespace Decoder {
 			Module::Init();
 				//    Config(0,25,6,16,128); // should be called by the user
 				fDebugFile=0;
-				Clear("");
+				Clear();
 				//    fName = "MPD Module (INFN MPD for GEM and more), use Config to dynamic config";
 				fName = "MPD Module";
 		}

--- a/SBSRPBeamSideHodo.cxx
+++ b/SBSRPBeamSideHodo.cxx
@@ -70,17 +70,17 @@ Int_t SBSRPBeamSideHodo::DefineVariables( EMode mode )
 }
 
 /*
- * ClearEvent()
+ * Clear()
  * called at the end of every event
  */
-void SBSRPBeamSideHodo::ClearEvent()
+void SBSRPBeamSideHodo::Clear( Option_t* opt )
 {
   // If we defined any new variables that we need to clear prior to the next event
   // clear them here:
   // fExample = 0.0;
 
-  // Make sure to call parent class's ClearEvent() also!
-  SBSGenericDetector::ClearEvent();
+  // Make sure to call parent class's Clear() also!
+  SBSGenericDetector::Clear(opt);
 }
 
 /*

--- a/SBSRPBeamSideHodo.h
+++ b/SBSRPBeamSideHodo.h
@@ -24,7 +24,7 @@ public:
   virtual Int_t   CoarseProcess( TClonesArray& tracks );
   virtual Int_t   FineProcess( TClonesArray& tracks );
   virtual Int_t   FindGoodHit(SBSElement *element);
-  virtual void ClearEvent();
+  virtual void    Clear( Option_t* opt="" );
 
   ClassDef(SBSRPBeamSideHodo,5)  // Describes scintillator plane with F1TDC as a detector
 };

--- a/SBSRPFarSideHodo.cxx
+++ b/SBSRPFarSideHodo.cxx
@@ -72,17 +72,17 @@ Int_t SBSRPFarSideHodo::DefineVariables( EMode mode )
 }
 
 /*
- * ClearEvent()
+ * Clear()
  * called at the end of every event
  */
-void SBSRPFarSideHodo::ClearEvent()
+void SBSRPFarSideHodo::Clear( Option_t* opt )
 {
   // If we defined any new variables that we need to clear prior to the next event
   // clear them here:
   // fExample = 0.0;
 
-  // Make sure to call parent class's ClearEvent() also!
-  SBSGenericDetector::ClearEvent();
+  // Make sure to call parent class's Clear() also!
+  SBSGenericDetector::Clear(opt);
 }
 
 /*

--- a/SBSRPFarSideHodo.h
+++ b/SBSRPFarSideHodo.h
@@ -24,7 +24,7 @@ public:
   virtual Int_t   CoarseProcess( TClonesArray& tracks );
   virtual Int_t   FineProcess( TClonesArray& tracks );
   virtual Int_t   FindGoodHit(SBSElement *element);
-  virtual void ClearEvent();
+  virtual void    Clear( Option_t* opt="" );
 
   ClassDef(SBSRPFarSideHodo,5)  // Describes scintillator plane with F1TDC as a detector
 };

--- a/SBSRaster.cxx
+++ b/SBSRaster.cxx
@@ -155,9 +155,10 @@ SBSRaster::~SBSRaster()
 
 }
 //______________________________________________________________________________
-void SBSRaster::Clear( Option_t* )
+void SBSRaster::Clear( Option_t* opt )
 {
   // Reset per-event data.
+  THaBeamDet::Clear(opt);
   fRawPos(0)=-1;
   fRawPos(1)=-1;
   fRawSlope(0)=-1;
@@ -171,8 +172,6 @@ void SBSRaster::Clear( Option_t* )
 //______________________________________________________________________________
 Int_t SBSRaster::Decode( const THaEvData& evdata )
 {
-
-  // clears the event structure
   // loops over all modules defined in the detector map
   // copies raw data into local variables
   // pedestal subtraction is not foreseen for the raster

--- a/SBSRaster.h
+++ b/SBSRaster.h
@@ -29,8 +29,8 @@
 class SBSRaster : public THaBeamDet {
 
 public:
-  SBSRaster( const char* name, const char* description = "",
-		   THaApparatus* a = NULL );
+  explicit SBSRaster( const char* name, const char* description = "",
+                      THaApparatus* a = nullptr );
   virtual ~SBSRaster();
 
   virtual void       Clear( Option_t* ="" );

--- a/SBSScalerEvtHandler.cxx
+++ b/SBSScalerEvtHandler.cxx
@@ -811,7 +811,7 @@ Int_t SBSScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata, Bool_t onlysync)
   //
   for (size_t j=0; j<scal_prev_read.size(); j++) scal_prev_read[j]=scal_present_read[j];
   //  
-  for (size_t j=0; j<scalers.size(); j++) scalers[j]->Clear("");
+  for (auto & scaler : scalers) scaler->Clear();
   
   return 1;
 }

--- a/SBSScintHit.cxx
+++ b/SBSScintHit.cxx
@@ -60,7 +60,7 @@ SBSScintHit::SBSScintHit(const SBSScintHit* pScHit, Int_t planenum, Int_t Bar_nd
 
 //___________________________________________________________________________
 void SBSScintHit::Clear(Option_t *) {
-  fScBar = 0;
+  fScBar = nullptr;
   fPlaneNum = -1;
   fBarNum = 0;
   fBarNum_nd = -1;

--- a/SBSScintHit.h
+++ b/SBSScintHit.h
@@ -19,7 +19,7 @@ class SBSScintHit : public TObject {
     
   SBSScintHit(const SBSScintBar* bar,Int_t planenum, Int_t barnum, 
 	      Double_t ypos, Double_t Tof, Double_t HitEnergy, Double_t Tdiff);   
-  SBSScintHit(const SBSScintHit* pScHit = 0);
+  explicit SBSScintHit(const SBSScintHit* pScHit = nullptr);
   SBSScintHit(const SBSScintHit* pScHit, Int_t clusternum);
   SBSScintHit(const SBSScintHit* pScHit, Int_t planenum, Int_t barnum_nd);
 

--- a/SBSScintHit.h
+++ b/SBSScintHit.h
@@ -26,19 +26,19 @@ class SBSScintHit : public TObject {
   virtual ~SBSScintHit();
 
   SBSScintBar* GetScintBar() const { return (SBSScintBar*)fScBar.GetObject(); }
-  Int_t GetPlaneNum() {return fPlaneNum;}
-  Int_t GetBarNum() {return fBarNum;}
-  Int_t GetBarNum_nd() {return fBarNum_nd;}
+  Int_t GetPlaneNum() const {return fPlaneNum;}
+  Int_t GetBarNum() const {return fBarNum;}
+  Int_t GetBarNum_nd() const {return fBarNum_nd;}
   
-  Double_t GetHitXPos() {return fHitXPos;}
-  Double_t GetHitYPos() {return fHitYPos;}
-  Double_t GetHitZPos() {return fHitZPos;}
+  Double_t GetHitXPos() const {return fHitXPos;}
+  Double_t GetHitYPos() const {return fHitYPos;}
+  Double_t GetHitZPos() const {return fHitZPos;}
   
-  Double_t GetHitTOF() {return fHitTOF;}
-  Double_t GetHitEdep() {return fHitEdep;}
-  Double_t GetHitTdiff() {return fTdiff;}
-  Int_t GetOrder() {return fOrder;}
-  Int_t GetClusterNum() {return fClusterNum;}
+  Double_t GetHitTOF() const {return fHitTOF;}
+  Double_t GetHitEdep() const {return fHitEdep;}
+  Double_t GetHitTdiff() const {return fTdiff;}
+  Int_t GetOrder() const {return fOrder;}
+  Int_t GetClusterNum() const {return fClusterNum;}
 
   void SetScintBar(SBSScintBar* bar) {fScBar=bar;}
   void SetPlaneNum(Int_t planenum) {fPlaneNum=planenum;}

--- a/SBSScintPlane.cxx
+++ b/SBSScintPlane.cxx
@@ -1449,11 +1449,11 @@ void SBSScintPlane::DeleteArrays()
 }
 
 //_____________________________________________________________________________
-inline 
-void SBSScintPlane::ClearEvent()
+void SBSScintPlane::Clear( Option_t* opt )
 {
     // Reset per-event data.
 
+  THaSubDetector::Clear(opt);
 #if 0
     const char cBig = 198;
 
@@ -1561,8 +1561,6 @@ Int_t SBSScintPlane::Decode( const THaEvData& evdata )
     // Decode scintillator data, correct TDC times and ADC amplitudes, and copy
     // the data to the local data members.
     static const char *here="Decode()";
-
-    ClearEvent();
 
     fEventCount++;
 

--- a/SBSScintPlane.h
+++ b/SBSScintPlane.h
@@ -83,6 +83,7 @@ public:
 	virtual ~SBSScintPlane();
 	virtual Int_t        InitOutput( THaOutput* output );
 
+        virtual void       Clear( Option_t* opt="" );
 	virtual Int_t      Decode( const THaEvData& );
 	virtual EStatus    Init( const TDatime& run_time); 
 	virtual Int_t      CoarseProcess( TClonesArray& tracks );
@@ -238,7 +239,6 @@ protected:
     Bool_t  fTooManyErrRefCh;       //flag whether there are too much error reference
 
 
-	void           ClearEvent();
 	void           DeleteArrays();
 	virtual Int_t  ReadDatabase( const TDatime& date );
 	virtual Int_t  DefineVariables( EMode mode = kDefine );

--- a/SBSTimingHodoscope.cxx
+++ b/SBSTimingHodoscope.cxx
@@ -866,10 +866,10 @@ Double_t SBSTimingHodoscope::TimeWalk(Double_t time, Double_t tot, Double_t time
   return tcorr;
  }
 /*
- * ClearEvent()
+ * Clear()
  * called at the end of every event
  */
-void SBSTimingHodoscope::ClearEvent()
+void SBSTimingHodoscope::Clear( Option_t* opt )
 {
   // If we defined any new variables that we need to clear prior to the next event
   // clear them here:
@@ -909,8 +909,8 @@ void SBSTimingHodoscope::ClearEvent()
   ClearHodoOutput(fMainClusBars);
   ClearHodoOutput(fOutClus);
   
-  // Make sure to call parent class's ClearEvent() also!
-  SBSGenericDetector::ClearEvent();
+  // Make sure to call parent class's Clear() also!
+  SBSGenericDetector::Clear(opt);
 }
 
 void SBSTimingHodoscope::ClearHodoOutput(SBSTimingHodoscopeOutput &out)

--- a/SBSTimingHodoscope.h
+++ b/SBSTimingHodoscope.h
@@ -41,7 +41,7 @@ public:
   virtual Int_t   CoarseProcess( TClonesArray& tracks );
   virtual Int_t   FineProcess( TClonesArray& tracks );
   /* virtual Int_t   FindGoodHit(SBSElement *element); */
-  virtual void    ClearEvent();
+  virtual void    Clear( Option_t* opt="" );
   // new functions
   Int_t   ConstructHodoscope();
   Double_t TimeWalk(Double_t time, Double_t tot, Double_t timewalk0, Double_t timewalk1);

--- a/SBSTimingHodoscope.h
+++ b/SBSTimingHodoscope.h
@@ -46,26 +46,26 @@ public:
   Int_t   ConstructHodoscope();
   Double_t TimeWalk(Double_t time, Double_t tot, Double_t timewalk0, Double_t timewalk1);
   
-  Int_t GetGoodBarsSize() {return fGoodBarIDsTDC.size();};
-  std::vector<Int_t> GetGoodBarsIDs() {return fGoodBarIDsTDC;};
-  std::vector<Double_t> GetGoodBarsMeanTimes() {return fGoodBarTDCmean;};
+  Int_t GetGoodBarsSize() const {return fGoodBarIDsTDC.size();};
+  std::vector<Int_t> GetGoodBarsIDs() const {return fGoodBarIDsTDC;};
+  std::vector<Double_t> GetGoodBarsMeanTimes() const {return fGoodBarTDCmean;};
   // time diff pos is hit pos along the bar length from time diff
-  std::vector<Double_t> GetGoodBarsTimeDiffPos() {return fGoodBarTDCpos;};
-  std::vector<Double_t> GetGoodBarsVPos() {return fGoodBarTDCvpos;};
-  Double_t GetGoodBarVPosElement(Int_t i) {
+  std::vector<Double_t> GetGoodBarsTimeDiffPos() const {return fGoodBarTDCpos;};
+  std::vector<Double_t> GetGoodBarsVPos() const {return fGoodBarTDCvpos;};
+  Double_t GetGoodBarVPosElement(Int_t i) const {
     if((Double_t)i<fGoodBarTDCvpos.size())
       return fGoodBarTDCvpos[i];
     else return -999.0;};
-  Double_t GetGoodBarHPosElement(Int_t i) {
+  Double_t GetGoodBarHPosElement(Int_t i) const {
     if((Double_t)i<fGoodBarTDCpos.size())
       return fGoodBarTDCpos[i];
     else return -999.0;};
-  Double_t GetGoodBarMeanTimeElement(Int_t i) {
+  Double_t GetGoodBarMeanTimeElement(Int_t i) const {
     if((Double_t)i<fGoodBarTDCmean.size())
       return fGoodBarTDCmean[i];
     else return -999.0;};
   
-  Int_t GetNClusters() {return fClusters.size();};
+  Int_t GetNClusters() const {return fClusters.size();};
   SBSTimingHodoscopeCluster* GetCluster(int i);
   
   Int_t GetID();

--- a/SBSTimingHodoscopeBar.cxx
+++ b/SBSTimingHodoscopeBar.cxx
@@ -20,11 +20,10 @@ fBarNum(barnum),fBarOff(baroff),fLPMT(leftpmt), fRPMT(rightpmt)
 
 //____________________________________________________________________
 
-SBSTimingHodoscopeBar::~SBSTimingHodoscopeBar() { 
-  ClearEvent();
-}
+SBSTimingHodoscopeBar::~SBSTimingHodoscopeBar() = default;
+
 //_____________________________________________________________
-void SBSTimingHodoscopeBar::ClearEvent() {
+void SBSTimingHodoscopeBar::Clear( Option_t* ) {
   fBarNum = 0;
   fBarOff = 0;
 }

--- a/SBSTimingHodoscopeBar.h
+++ b/SBSTimingHodoscopeBar.h
@@ -41,7 +41,7 @@ public:
 	void SetBarOff( Int_t baroff ) {fBarOff=baroff;}
 	/* void SetLPMT( SBSTimingHodoscopePMT* leftpmt) {fLPMT=leftpmt;} */
 	/* void SetRPMT( SBSTimingHodoscopePMT* rightpmt) {fRPMT=rightpmt;} */
-	void ClearEvent();
+	virtual void Clear( Option_t* opt="" );
 	
 	double GetMeanTime(){return fMeanTime;};
 	double GetTimeDiff(){return fTimeDiff;};

--- a/SBSTimingHodoscopeBar.h
+++ b/SBSTimingHodoscopeBar.h
@@ -43,13 +43,13 @@ public:
 	/* void SetRPMT( SBSTimingHodoscopePMT* rightpmt) {fRPMT=rightpmt;} */
 	virtual void Clear( Option_t* opt="" );
 	
-	double GetMeanTime(){return fMeanTime;};
-	double GetTimeDiff(){return fTimeDiff;};
-	double GetMeanToT(){return fMeanToT;};
-	double GetHitPos(){return fHitPos;};
-	double GetElementPos(){return fElementPos;};
-	SBSData::TDCHit GetLeftHit(){return fLeftHit;};
-	SBSData::TDCHit GetRightHit(){return fRightHit;};
+	double GetMeanTime() const {return fMeanTime;};
+	double GetTimeDiff() const {return fTimeDiff;};
+	double GetMeanToT() const {return fMeanToT;};
+	double GetHitPos() const {return fHitPos;};
+	double GetElementPos() const {return fElementPos;};
+	SBSData::TDCHit GetLeftHit() const {return fLeftHit;};
+	SBSData::TDCHit GetRightHit() const {return fRightHit;};
 
 	void SetMeanTime(double val){fMeanTime = val;};
 	void SetTimeDiff(double val){fTimeDiff = val;};

--- a/SBSTimingHodoscopeCluster.cxx
+++ b/SBSTimingHodoscopeCluster.cxx
@@ -87,7 +87,7 @@ Bool_t SBSTimingHodoscopeCluster::AddElement(SBSTimingHodoscopeBar* bar) {
 }
 
 //_____________________________________________________________
-void SBSTimingHodoscopeCluster::ClearEvent() {
+void SBSTimingHodoscopeCluster::Clear( Option_t* ) {
   fMult=0;fXmean=fYmean=fTmean=0.;
   fElements.clear();
 }

--- a/SBSTimingHodoscopeCluster.h
+++ b/SBSTimingHodoscopeCluster.h
@@ -36,7 +36,7 @@ public:
     SBSTimingHodoscopeBar* GetElement(UInt_t i);
     std::vector<SBSTimingHodoscopeBar*>& GetElements() {return fElements;}
 
-    Int_t GetSize() {return fMult;}
+    Int_t GetSize() const {return fMult;}
 
     Bool_t AddElement(SBSTimingHodoscopeBar* bar);
 

--- a/SBSTimingHodoscopeCluster.h
+++ b/SBSTimingHodoscopeCluster.h
@@ -40,7 +40,7 @@ public:
 
     Bool_t AddElement(SBSTimingHodoscopeBar* bar);
 
-    void ClearEvent();
+    virtual void Clear( Option_t* opt="" );
 
 private:
 

--- a/SBSTimingHodoscopeCluster.h
+++ b/SBSTimingHodoscopeCluster.h
@@ -15,7 +15,7 @@ class SBSTimingHodoscopeCluster : public TObject {
 public:
 
     SBSTimingHodoscopeCluster();
-    SBSTimingHodoscopeCluster(Int_t nmaxblk);
+    explicit SBSTimingHodoscopeCluster(Int_t nmaxblk);
     SBSTimingHodoscopeCluster(Int_t nmaxblk, SBSTimingHodoscopeBar* bar);
     virtual ~SBSTimingHodoscopeCluster();
 

--- a/SBSTimingHodoscopePMT.cxx
+++ b/SBSTimingHodoscopePMT.cxx
@@ -11,7 +11,15 @@
 ClassImp(SBSTimingHodoscopePMT);
 
 //_____________________________________________________________________________
-SBSTimingHodoscopePMT::SBSTimingHodoscopePMT( SBSElement* element, Double_t walkpar0, Double_t walkpar1, Int_t barnum, Int_t side, Int_t id) : fPMTElement(element), fTimeWalkParameter0(walkpar0), fTimeWalkParameter1(walkpar1), fBarNum(barnum), fSide(side), fId(id){
+SBSTimingHodoscopePMT::SBSTimingHodoscopePMT(
+  SBSElement* element, Double_t walkpar0, Double_t walkpar1, Int_t barnum,
+  Int_t side, Int_t id )
+  : fPMTElement(element),
+    fTimeWalkParameter0(walkpar0),
+    fTimeWalkParameter1(walkpar1),
+    fBarNum(barnum),
+    fSide(side),
+    fId(id) {
 }
 
 //_____________________________________________________________________________

--- a/SBSTimingHodoscopePMT.cxx
+++ b/SBSTimingHodoscopePMT.cxx
@@ -15,11 +15,11 @@ SBSTimingHodoscopePMT::SBSTimingHodoscopePMT( SBSElement* element, Double_t walk
 }
 
 //_____________________________________________________________________________
-SBSTimingHodoscopePMT::~SBSTimingHodoscopePMT() {
-  ClearEvent();
-}
+SBSTimingHodoscopePMT::~SBSTimingHodoscopePMT() = default;
+
 //_____________________________________________________________
-void SBSTimingHodoscopePMT::ClearEvent() {
+void SBSTimingHodoscopePMT::Clear( Option_t* )
+{
   // fPMTElement = 0;
   fTimeWalkParameter0 = 0.0;
   fTimeWalkParameter1 = 0.0;

--- a/SBSTimingHodoscopePMT.h
+++ b/SBSTimingHodoscopePMT.h
@@ -35,7 +35,7 @@ public:
   void SetBarNum(Int_t barnum) {fBarNum=barnum;}
   void SetSide(Int_t side) {fSide=side;}
   void SetId(Int_t id) {fId=id;}
-  void ClearEvent();
+  void Clear( Option_t* opt="" );
 
  /* private:  */
  protected:

--- a/SBSTimingHodoscopePMT.h
+++ b/SBSTimingHodoscopePMT.h
@@ -15,7 +15,7 @@
 /* #include "TObject.h" */
 #include "SBSElement.h"
 
-class SBSTimingHodoscopePMT{
+class SBSTimingHodoscopePMT {
 
 public:
   SBSTimingHodoscopePMT( SBSElement* element, Double_t walkpar0, Double_t walkpar1,Int_t barnum, Int_t side, Int_t id );


### PR DESCRIPTION
As discussed over Slack, I refactored the ClearEvent functions of the various Detector classes to match the signature of THaAnalysisObject::Clear. Clear is called automatically by THaAnalyzer right before Decode, so there is no need to clear anything explicitly at the start of Decode, as was done in SBSGenericDetector::Decode, for example.

I also took the opportunity to make a few coding tweaks, mostly making various Get functions const. These changes are far from complete, but it's what came across my radar while working on the Clear business.

