### PR TITLE
List of changes:

### DIFF
--- a/SBSBBShower.cxx
+++ b/SBSBBShower.cxx
@@ -193,28 +193,30 @@ void SBSBBShower::MakeMainCluster(Int_t iclust)
   if(!fClusters.empty() && iclust >= 0 && iclust < fClusters.size() ) {
     SBSCalorimeterCluster *clus = fClusters[iclust];
     fMainclus.e.push_back(clus->GetE());
+    fMainclus.again.push_back(clus->GetAgain());
     fMainclus.atime.push_back(clus->GetAtime());
     fMainclus.tdctime.push_back(clus->GetTDCtime());
-    fMainclus.e_c.push_back(clus->GetE()*(fConst + fSlope*fAccCharge));
+    //fMainclus.e_c.push_back(clus->GetE()*(fConst + fSlope*fAccCharge));
     fMainclus.x.push_back(clus->GetX());
     fMainclus.y.push_back(clus->GetY());
     fMainclus.n.push_back(clus->GetMult());
     fMainclus.blk_e.push_back(clus->GetEblk());
-    fMainclus.blk_e_c.push_back(clus->GetEblk()*(fConst + fSlope*fAccCharge));
+    //fMainclus.blk_e_c.push_back(clus->GetEblk()*(fConst + fSlope*fAccCharge));
     fMainclus.id.push_back(clus->GetElemID());
     fMainclus.row.push_back(clus->GetRow());
     fMainclus.col.push_back(clus->GetCol());
     fBestClusterIndex = iclust;
   } else { //Make an "empty" cluster:
     fMainclus.e.push_back( 0.0 );
+    fMainclus.again.push_back( 0.0 );
     fMainclus.atime.push_back( -1000.0 );
     fMainclus.tdctime.push_back( -1000.0 );
-    fMainclus.e_c.push_back( 0.0 );
+    //fMainclus.e_c.push_back( 0.0 );
     fMainclus.x.push_back( 0.0 );
     fMainclus.y.push_back( 0.0 );
     fMainclus.n.push_back( 0 );
     fMainclus.blk_e.push_back( 0.0 );
-    fMainclus.blk_e_c.push_back( 0.0 );
+    //fMainclus.blk_e_c.push_back( 0.0 );
     fMainclus.id.push_back( -1 );
     fMainclus.row.push_back( -1 );
     fMainclus.col.push_back( -1 );

--- a/SBSBigBite.cxx
+++ b/SBSBigBite.cxx
@@ -622,7 +622,8 @@ Int_t SBSBigBite::CoarseReconstruct()
 	// TODO: so far we use only the "main" cluster... 
 	//       we might want to check the others...
 	//y_bcp+= BBTotalShower->GetShower()->GetY()/(BBTotalShower->GetShower()->SizeCol()/sqrt(12));
-	Etot+= BBTotalShower->GetShower()->GetECorrected();
+	//Etot+= BBTotalShower->GetShower()->GetECorrected();
+	Etot+= BBTotalShower->GetShower()->GetE();
 
 	double weightxSH = pow(fSigmaX_shower,-2);
 	double weightySH = pow(fSigmaY_shower,-2);
@@ -648,8 +649,10 @@ Int_t SBSBigBite::CoarseReconstruct()
 	double weightxPS = pow(fSigmaX_preshower,-2);
 	double weightyPS = pow(fSigmaY_preshower,-2);
 	
-	Etot+= BBTotalShower->GetPreShower()->GetECorrected();
-	EpsEtotRatio = BBTotalShower->GetPreShower()->GetECorrected()/Etot;
+	// Etot+= BBTotalShower->GetPreShower()->GetECorrected();
+	// EpsEtotRatio = BBTotalShower->GetPreShower()->GetECorrected()/Etot;
+	Etot+= BBTotalShower->GetPreShower()->GetE();
+	EpsEtotRatio = BBTotalShower->GetPreShower()->GetE()/Etot;
 	fEpsEtotRatio.push_back(EpsEtotRatio);
 	fEtot.push_back(Etot);
 	// x_bcp+= BBTotalShower->GetPreShower()->GetX()/(pow(BBTotalShower->GetPreShower()->SizeRow(), 2)/12.);

--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -56,16 +56,17 @@ struct SBSCalBlocks {
 
 struct SBSCalorimeterOutput {
   std::vector<Double_t> e;   //< []
+  std::vector<Double_t> again;   //< []
   std::vector<Double_t> atime;   //< []
   std::vector<Double_t> tdctime;   //< []
-  std::vector<Double_t> e_c;   //< []
+  //std::vector<Double_t> e_c;   //< []
   std::vector<Double_t> x;   //< []
   std::vector<Double_t> y;   //< []
   std::vector<Double_t> row; //< []
   std::vector<Double_t> col; //< []
   std::vector<Int_t>   n;   // Number of elements
   std::vector<Double_t> blk_e;   // block energy of max energy block
-  std::vector<Double_t> blk_e_c; // block corrected energy of max energy block
+  //std::vector<Double_t> blk_e_c; // block corrected energy of max energy block
   std::vector<Int_t>   id;      // block id of max energy block
 };
    
@@ -84,13 +85,14 @@ public:
 
   // Get information from the main cluster
   Double_t GetE();             //< Main cluster energy
+  Double_t GetAgain();         //< Pedestal subtracted ADC integral (pC)
   Double_t GetAtime();         //< Main cluster ADC time of max block
   Double_t GetTDCtime();         //< Main cluster ADC time of max block
-  Double_t GetECorrected();    //< Main cluster corrected energy
+  /* Double_t GetECorrected();    //< Main cluster corrected energy */
   Double_t GetX();             //< Main cluster energy average x
   Double_t GetY();             //< Main cluster energy average y
   Double_t GetEBlk();          //< Main cluster energy of max block in cluster
-  Double_t GetEBlkCorrected(); //< Main cluster corrected energy of max block in cluster
+  /* Double_t GetEBlkCorrected(); //< Main cluster corrected energy of max block in cluster */
   Int_t GetNblk();            //< Number of blocks in main cluster
   Int_t GetBlkID();           //< ID/block number of max energy block in cluster
   Int_t GetRow();             //< Main cluster row of max block
@@ -186,6 +188,10 @@ inline Double_t SBSCalorimeter::GetE() {
   return GetVVal(fMainclus.e);
 }
 
+inline Double_t SBSCalorimeter::GetAgain() {
+  return GetVVal(fMainclus.again);
+}
+
 inline Double_t SBSCalorimeter::GetAtime() {
   return GetVVal(fMainclus.atime);
 }
@@ -194,17 +200,17 @@ inline Double_t SBSCalorimeter::GetTDCtime() {
   return GetVVal(fMainclus.tdctime);
 }
 
-inline Double_t SBSCalorimeter::GetECorrected() {
-  return GetVVal(fMainclus.e_c);
-}
+/* inline Double_t SBSCalorimeter::GetECorrected() { */
+/*   return GetVVal(fMainclus.e_c); */
+/* } */
 
 inline Double_t SBSCalorimeter::GetEBlk() {
   return GetVVal(fMainclus.blk_e);
 }
 
-inline Double_t SBSCalorimeter::GetEBlkCorrected() {
-  return GetVVal(fMainclus.blk_e_c);
-}
+/* inline Double_t SBSCalorimeter::GetEBlkCorrected() { */
+/*   return GetVVal(fMainclus.blk_e_c); */
+/* } */
 
 inline Double_t SBSCalorimeter::GetX() {
   return GetVVal(fMainclus.x);

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -26,6 +26,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
     fE = block->GetE();
     fEblk = block->GetE();
     fMult = 1;
+    fAgain = block->GetAgain();
     fAtime  = block->GetAtime();
     fTDCtime  = block->GetTDCtime();
     fRow  = block->GetRow();
@@ -45,6 +46,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk)
     fE = 0;
     fEblk = 0;
     fMult = 0;
+    fAgain = 0.;
     fAtime = 0;
     fTDCtime = 0;
     fRow  = -1;
@@ -61,6 +63,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster() {
     fE = kBig;
     fEblk = 0;
     fMult = 0;
+    fAgain = 0.;
     fAtime = 0;
     fTDCtime = 0;
     fRow  = -1;
@@ -85,6 +88,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
         if(block->GetE() > fEblk) {
           fEblk = block->GetE();
           fAtime = block->GetAtime();
+	  fAgain = block->GetAgain();
           fTDCtime = block->GetTDCtime();
           fRow = block->GetRow();
           fCol = block->GetCol();
@@ -104,6 +108,7 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
 void SBSCalorimeterCluster::Clear( Option_t* opt ) {
     fMult=0;fX=fY=fE=0.;
     fEblk=0;
+    fAgain=0.;
     fAtime=0;
     fTDCtime=0;
     fRow=fCol=-1;

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -22,6 +22,7 @@ public:
     Double_t GetX() const {return fX;}
     Double_t GetY() const {return fY;}
     Double_t GetE() const {return fE;}
+    Double_t GetAgain() const {return fAgain;}
     Double_t GetAtime() const {return fAtime;}
     Double_t GetTDCtime() const {return fTDCtime;}
     Double_t GetEblk() const {return fEblk;}
@@ -37,6 +38,7 @@ public:
     void SetX(Double_t var) {fX=var;}
     void SetY(Double_t var) {fY=var;}
     void SetE(Double_t var) {fE=var;}
+    void SetAgain(Double_t var) {fAgain=var;}
     void SetAtime(Double_t var) {fAtime=var;}
     void SetTDCtime(Double_t var) {fTDCtime=var;}
     void SetEblk(Double_t var) {fEblk=var;}
@@ -58,8 +60,8 @@ private:
 
     Double_t fX;       // x position of the center
     Double_t fY;       // y position of the center
-
     Double_t fE;       // Energy deposit in block
+    Double_t fAgain;   // ADC gain coefficient (GeV/pC)
     Double_t fAtime;       // ADC time  of block with highest E
     Double_t fTDCtime;       // TDC time  of block with highest E
     Double_t fEblk;    // Energy of block with highest E

--- a/SBSElement.cxx
+++ b/SBSElement.cxx
@@ -15,7 +15,7 @@ ClassImp(SBSElement);
 // Constructor for generic Element (no-data)
 SBSElement::SBSElement(Double_t x, Double_t y,
     Double_t z, Int_t row, Int_t col, Int_t layer, Int_t id) :
-  fX(x), fY(y), fZ(z), fE(0), fAtime(kBig), fTDCtime(kBig), fRow(row), fCol(col), fLayer(layer),
+  fX(x), fY(y), fZ(z), fE(0), fAgain(0), fAtime(kBig), fTDCtime(kBig), fRow(row), fCol(col), fLayer(layer),
   fStat(0), fID(id), fADC(nullptr), fTDC(nullptr), fWaveform(nullptr)
 {
 }
@@ -47,6 +47,7 @@ Bool_t SBSElement::HasADCData()
 void SBSElement::Clear( Option_t* opt )
 {
   fE = 0; // Reset calibrated energy for given event
+  fAgain = 0.;
   fStat = 0; // Reset status to 0, unseen
   if(fADC)
     fADC->Clear();

--- a/SBSElement.h
+++ b/SBSElement.h
@@ -26,6 +26,7 @@ public:
   Double_t GetY()     const { return fY; }
   Double_t GetZ()     const { return fZ; }
   Double_t GetE()     const { return fE; }
+  Double_t GetAgain()     const { return fAgain; }
   Double_t GetAtime()     const { return fAtime; }
   Double_t GetTDCtime()     const { return fTDCtime; }
   Int_t   GetRow()   const { return fRow; }
@@ -42,6 +43,7 @@ public:
   void SetY(Double_t var)    { fY = var; }
   void SetZ(Double_t var)    { fZ = var; }
   void SetE(Double_t var)    { fE = var; }
+  void SetAgain(Double_t var)    { fAgain = var; }
   void SetAtime(Double_t var)    { fAtime = var; }
   void SetTDCtime(Double_t var)    { fTDCtime = var; }
   void SetRow(Int_t var)    { fRow = var; }
@@ -66,6 +68,7 @@ protected:
   Double_t fY;       ///< relative y position of the center
   Double_t fZ;       ///< relative z position of the center
   Double_t fE;       ///< calibrated energy of event in this block
+  Double_t fAgain;   ///< ADC gain coefficient (GeV/pC)
   Double_t fAtime;       ///< ADC time of event in this block
   Double_t fTDCtime;       ///< TDC time of event in this block
 


### PR DESCRIPTION
	1. Disabled *.e_c and *.eblk_c variables. Since they were just mere copies of *.e and *.eblk respectively.
	2. Added *.againblk, *.clus.again, *.clus_blk.again variables. They contain ADC gain coefficients (GeV/pC) for the blocks in cluster. This will be hugely useful for calorimeter calibration.