### PR TITLE
Feature charge asymmetry

### DIFF
--- a/SBSScalerHelicity.cxx
+++ b/SBSScalerHelicity.cxx
@@ -60,6 +60,7 @@ SBSScalerHelicity::SBSScalerHelicity( const char* name, const char* description,
    for (UInt_t j=0; j<32; j++){
       fScalerCumulative[j] = 0;
    }
+   fFADCQrtHel = 0;
 }
 //_____________________________________________________________________________
 SBSScalerHelicity::~SBSScalerHelicity()
@@ -195,29 +196,58 @@ Int_t SBSScalerHelicity::Begin( THaRunBase* )
    TString branchInfo;
 
    int j=0;
-   const int NB = 49;
+   const int NB = 130;
    TString branchName[NB];
    branchName[0]  = Form("%s.error.code"           ,armName.Data());
    branchName[1]  = Form("%s.ring.seed"            ,armName.Data());
    branchName[2]  = Form("%s.ring.seedReported"    ,armName.Data());
    branchName[3]  = Form("%s.ring.seedActual"      ,armName.Data());
    branchName[4]  = Form("%s.ring.phaseReported"   ,armName.Data());
-   branchName[5]  = Form("%s.ring.polarityReported",armName.Data());
-   branchName[6]  = Form("%s.ring.polarityActual"  ,armName.Data());
-   branchName[7]  = Form("%s.ring.U3Plus"          ,armName.Data());
-   branchName[8]  = Form("%s.ring.U3Minus"         ,armName.Data());
-   branchName[9]  = Form("%s.ring.T3Plus"          ,armName.Data());
-   branchName[10] = Form("%s.ring.T3Minus"         ,armName.Data());
-   branchName[11] = Form("%s.ring.T5Plus"          ,armName.Data());
-   branchName[12] = Form("%s.ring.T5Minus"         ,armName.Data());
-   branchName[13] = Form("%s.ring.T10Plus"         ,armName.Data());
-   branchName[14] = Form("%s.ring.T10Minus"        ,armName.Data());
-   branchName[15] = Form("%s.ring.TimePlus"        ,armName.Data());
-   branchName[16] = Form("%s.ring.TimeMinus"       ,armName.Data());
+   //   branchName[5]  = Form("%s.ring.polarityReported",armName.Data());
+   //   branchName[6]  = Form("%s.ring.polarityActual"  ,armName.Data());
+   branchName[5]  = Form("%s.ring.UnewPlus"        ,armName.Data());
+   branchName[6] = Form("%s.ring.UnewMinus"        ,armName.Data());
+   branchName[7]  = Form("%s.ring.DnewPlus"        ,armName.Data());
+   branchName[8]  = Form("%s.ring.DnewMinus"       ,armName.Data());
+   branchName[9] = Form("%s.ring.U1Plus"           ,armName.Data());
+   branchName[10] = Form("%s.ring.U1Minus"         ,armName.Data());
+   branchName[11] = Form("%s.ring.D1Plus"          ,armName.Data());
+   branchName[12] = Form("%s.ring.D1Minus"         ,armName.Data());
+   branchName[13] = Form("%s.ring.D3Plus"          ,armName.Data());
+   branchName[14] = Form("%s.ring.D3Minus"         ,armName.Data());
+   branchName[15] = Form("%s.ring.D10Plus"         ,armName.Data());
+   branchName[16] = Form("%s.ring.D10Minus"        ,armName.Data());
 
    for(int i=0;i<32;i++){
       j = 17 + i;
       branchName[j] = Form("%s.cumulative.Ch%d",armName.Data(),i);
+   }
+
+   branchName[49] = Form("%s.hel.ErrorCode"        ,armName.Data());
+   branchName[50] = Form("%s.hel.EvtNum"           ,armName.Data());
+   branchName[51] = Form("%s.hel.PattNum"          ,armName.Data());
+   branchName[52] = Form("%s.hel.PattPhase"        ,armName.Data());
+   branchName[53] = Form("%s.hel.PatternSeed"      ,armName.Data());
+   branchName[54] = Form("%s.hel.PatternPolarity"  ,armName.Data());
+   branchName[55] = Form("%s.hel.EvtPolarity"      ,armName.Data());
+   branchName[56] = Form("%s.hel.ReportedQrtHel"   ,armName.Data());
+
+   branchName[57] = Form("%s.ring.FinalQrtHel"     ,armName.Data());
+   branchName[58] = Form("%s.ring.FinalEvtNum"     ,armName.Data());
+   branchName[59] = Form("%s.ring.FinalPatNum"     ,armName.Data());
+   branchName[60] = Form("%s.ring.FinalSeed"       ,armName.Data());
+
+   branchName[61] = Form("%s.fadc.ReportedHelicity",armName.Data());
+   branchName[62] = Form("%s.fadc.PatternSync"     ,armName.Data());
+   branchName[63] = Form("%s.fadc.TSettle"         ,armName.Data());
+   branchName[64] = Form("%s.fadc.ReportedQrtHel"  ,armName.Data());
+
+   branchName[65] = Form("%s.ring.PattPhase"       ,armName.Data());
+
+   for(int i=0;i<32;i++){
+      j = 66 + 2*i;
+      branchName[j]   = Form("%s.Yield.Ch%d",armName.Data(),i);
+      branchName[j+1] = Form("%s.Diff.Ch%d",armName.Data(),i);
    }
 
    if(!fHelScalerTree){
@@ -262,7 +292,55 @@ Int_t SBSScalerHelicity::Begin( THaRunBase* )
 	 j = 17 + i; 
 	 branchInfo = Form("%s/L",branchName[j].Data()); 
 	 fHelScalerTree->Branch(branchName[j].Data(),&fScalerCumulative[i],branchInfo.Data()); 
-      } 
+      }
+      branchInfo = Form("%s/i",branchName[49].Data());
+      fHelScalerTree->Branch(branchName[49].Data(),&fHelErrorCond,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[50].Data());
+      fHelScalerTree->Branch(branchName[50].Data(),&fNumEvents,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[51].Data());
+      fHelScalerTree->Branch(branchName[51].Data(),&fNumPatterns,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[52].Data());
+      fHelScalerTree->Branch(branchName[52].Data(),&fPatternPhase,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[53].Data());
+      fHelScalerTree->Branch(branchName[53].Data(),&fSeedValue,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[54].Data());
+      fHelScalerTree->Branch(branchName[54].Data(),&fPatternHel,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[55].Data());
+      fHelScalerTree->Branch(branchName[55].Data(),&fEventPolarity,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[56].Data());
+      fHelScalerTree->Branch(branchName[56].Data(),&fReportedQrtHel,branchInfo.Data());
+
+      branchInfo = Form("%s/i",branchName[57].Data());
+      fHelScalerTree->Branch(branchName[57].Data(),&fRingFinalQrtHel,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[58].Data());
+      fHelScalerTree->Branch(branchName[58].Data(),&fRingFinalEvtNum,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[59].Data());
+      fHelScalerTree->Branch(branchName[59].Data(),&fRingFinalPatNum,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[60].Data());
+      fHelScalerTree->Branch(branchName[60].Data(),&fRingFinalSeed,branchInfo.Data());
+
+      branchInfo = Form("%s/i",branchName[61].Data());
+      fHelScalerTree->Branch(branchName[61].Data(),&fFADCHelicity,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[62].Data());
+      fHelScalerTree->Branch(branchName[62].Data(),&fFADCPatSync,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[63].Data());
+      fHelScalerTree->Branch(branchName[63].Data(),&fFADCTSettle,branchInfo.Data());
+      branchInfo = Form("%s/i",branchName[64].Data());
+      fHelScalerTree->Branch(branchName[64].Data(),&fFADCQrtHel,branchInfo.Data());
+
+      branchInfo = Form("%s/i",branchName[65].Data());
+      fHelScalerTree->Branch(branchName[65].Data(),&fRingPattPhase,branchInfo.Data());
+
+      for(int i=0;i<32;i++){
+	j = 66 + 2*i;
+	branchInfo = Form("%s/L",branchName[j].Data()); 
+	fHelScalerTree->Branch(branchName[j].Data(),&fScalerYield[i],branchInfo.Data());
+	j = 66 + 2*i + 1;
+	branchInfo = Form("%s/L",branchName[j].Data()); 
+	fHelScalerTree->Branch(branchName[j].Data(),&fScalerDiff[i],branchInfo.Data());
+      }
+
+
    }
 
    return 0;

--- a/SBSScalerHelicity.h
+++ b/SBSScalerHelicity.h
@@ -40,6 +40,21 @@ class SBSScalerHelicity : public THaHelicityDet, public SBSScalerHelicityReader 
 
       void SetVerbosity(int v) { fVerbosity = v; } 
 
+      void SetHelicityDelay(Int_t delay){
+	if (delay<0) {
+	  std::cerr << "****  Helicity Delay cannot be negative.  Force to zero." 
+		    << std::endl;
+	  fHelicityDelay = 0;
+	}
+	else if (delay>64) {
+	  std::cerr << "****  Helicity Delay cannot be greater than 64.  Force to zero." 
+		    << std::endl;
+	} else {
+	  fHelicityDelay = delay;
+	}
+      }
+
+
    protected:
       virtual void  FillHisto();
       void  CheckTIRvsRing( UInt_t eventnumber );
@@ -58,6 +73,7 @@ class SBSScalerHelicity : public THaHelicityDet, public SBSScalerHelicityReader 
       UInt_t fQWEAKNPattern; // maximum of event in the pattern
       Bool_t HWPIN;
 
+      Int_t fHelicityDelay;
 
       Int_t fQrt;
       Int_t fTSettle;

--- a/SBSScalerHelicity.h
+++ b/SBSScalerHelicity.h
@@ -77,6 +77,19 @@ class SBSScalerHelicity : public THaHelicityDet, public SBSScalerHelicityReader 
       // Long64_t fScalerCumulativePlus[32];
       // Long64_t fScalerCumulativeMinus[32];
 
+      UInt_t fRingFinalQrtHel;
+      UInt_t fRingFinalEvtNum;
+      UInt_t fRingFinalPatNum;
+      UInt_t fRingFinalSeed;
+      UInt_t fRingPattPhase;
+      UInt_t fRingHelicitySum;
+
+      Long_t fTimeStampYield;
+      Long_t fTimeStampDiff;
+      Long_t fScalerYield[32];
+      Long_t fScalerDiff[32];
+
+
       UInt_t fRing_NSeed; //number of event collected for seed
       UInt_t fRingU3plus, fRingU3minus;
       UInt_t fRingT3plus, fRingT3minus;

--- a/SBSScalerHelicityReader.cxx
+++ b/SBSScalerHelicityReader.cxx
@@ -35,6 +35,9 @@ SBSScalerHelicityReader::SBSScalerHelicityReader()
    fQWEAKDebug(0),      // Debug level
    fHaveROCs(false),   // Required ROCs are defined
    fNegGate(false),    // Invert polarity of gate, so that 0=active
+   fFADCLow_min(37000),  fFADCLow_max(49000),
+   fFADCHigh_min(80000), fFADCHigh_max(92000),
+   fRingFinalEvtNum(1),fRingFinalPatNum(0),fRingFinalSeed(0),
    fVerbosity(0),
    fHistoR{}
 {
@@ -235,19 +238,48 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
       return -1;
    }
 
-   UInt_t fadcdata[8];
-
    //  LHRS FADC helicity bits
-   fadcdata[0] = 0;
-   fadcdata[1] = evdata.GetData( Decoder::kPulseIntegral,10,14,15,0 );
-   fadcdata[2] = evdata.GetData( Decoder::kPulseIntegral,10,14,14,0 );
-   fadcdata[3] = evdata.GetData( Decoder::kPulseIntegral,10,14,13,0 );
+   fFADCSpare    = evdata.GetData( Decoder::kPulseIntegral,10,14,12,0 );
+   fFADCHelicity = evdata.GetData( Decoder::kPulseIntegral,10,14,15,0 );
+   fFADCPatSync  = evdata.GetData( Decoder::kPulseIntegral,10,14,14,0 );
+   fFADCTSettle  = evdata.GetData( Decoder::kPulseIntegral,10,14,13,0 );
+
+   UInt_t hel, patsync, tsettle;
+   if (fFADCHelicity>=fFADCLow_min && fFADCHelicity<=fFADCLow_max){
+     hel = 0;
+   }
+   else if (fFADCHelicity>=fFADCHigh_min && fFADCHelicity<=fFADCHigh_max){
+     hel = 1;
+   }
+   else {
+     hel = 0x1000;
+   }
+   if (fFADCPatSync>=fFADCLow_min && fFADCPatSync<=fFADCLow_max){
+     patsync = 0;
+   }
+   else if (fFADCPatSync>=fFADCHigh_min && fFADCPatSync<=fFADCHigh_max){
+     patsync = 0x10;
+   }
+   else {
+     patsync = 0x2000;
+   }
+   if (fFADCTSettle>=fFADCLow_min && fFADCTSettle<=fFADCLow_max){
+     tsettle = 0;
+   }
+   else if (fFADCTSettle>=fFADCHigh_min && fFADCTSettle<=fFADCHigh_max){
+     tsettle = 0x100;
+   }
+   else {
+     tsettle = 0x4000;
+   }
+   fFADCQrtHel = hel + patsync + tsettle;
+
 
    //  SBS FADC helicity bits
-   fadcdata[4] = evdata.GetData( Decoder::kPulseIntegral,1,20,15,0 );
-   fadcdata[5] = evdata.GetData( Decoder::kPulseIntegral,1,20,14,0 );
-   fadcdata[6] = evdata.GetData( Decoder::kPulseIntegral,1,20,13,0 );
-   fadcdata[7] = evdata.GetData( Decoder::kPulseIntegral,1,20,12,0 );
+   fFADCSpare_sbs    = evdata.GetData( Decoder::kPulseIntegral,1,20,15,0 );
+   fFADCHelicity_sbs = evdata.GetData( Decoder::kPulseIntegral,1,20,14,0 );
+   fFADCPatSync_sbs  = evdata.GetData( Decoder::kPulseIntegral,1,20,13,0 );
+   fFADCTSettle_sbs  = evdata.GetData( Decoder::kPulseIntegral,1,20,12,0 );
    UInt_t hroc = fROCinfo[kHel].roc;
    UInt_t len = evdata.GetRocLength(hroc);
    //  if (len <= 4) 
@@ -274,8 +306,33 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
 	 if(fVerbosity>0) std::cout << std::dec << "[SBSScalerHelicityReader::ReadDatabase]: Numread = " << numread << std::endl;
 	 fIRing = numread;
 	 for (UInt_t i=0; i<numread; i++){
+	   UInt_t qrthel = lbuff[index+1];
+	   Long_t helsign = +1;
+	   if ((qrthel & 0x1)==0) helsign = -1;
+	   fRingFinalQrtHel = qrthel;
+	   fTimeStampRing[i] = lbuff[index+0];
+	   fHelicityRing[i]  = (qrthel & 0x1);
+	   fPatternRing[i]   = (qrthel & 0x10);
+	   //  Keep track of event and pattern number
+	   fRingFinalEvtNum++;
+	   fRingPattPhase++;
+	   if ((qrthel & 0x10)==0x10){
+	     fRingFinalPatNum++;
+	     fRingPattPhase = 0;
+	     fRingFinalSeed = ((fRingFinalSeed<<1)&0x3ffffffe)|(qrthel & 0x1);
+	     // std::cout << "Ring seed value: " << std::hex << fRingFinalSeed
+	     // 	       << std::dec << "; qrthel==" << qrthel
+	     // 	       <<std::endl;
+	   }
 	    for (UInt_t j=0; j<nchan; j++){
 	       fScalerRing[i][j]=lbuff[index+2+j];
+	       if (fRingPattPhase==0){
+		 fScalerYield[j] = +1 * lbuff[index+2+j];
+		 fScalerDiff[j]  = helsign * lbuff[index+2+j];
+	       } else {
+		 fScalerYield[j] += +1 * lbuff[index+2+j];
+		 fScalerDiff[j]  += helsign * lbuff[index+2+j];
+	       }
 	    }
 	    /*
 	       std::cout << "\n\nindex : Clock, qrthel, chan0, chan9, chan15:  "
@@ -297,33 +354,33 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
       /* std::cout <<std::hex << lbuff[0] << " " <<lbuff[1]
        *           <<std::endl;
        */
-      UInt_t fHelErrorCond   = lbuff[2];
-      UInt_t fNumEvents      = lbuff[3];
-      UInt_t fNumPatterns    = lbuff[4];
-      UInt_t fPatternPhase   = lbuff[5];
-      UInt_t fSeedValue      = lbuff[6];
-      UInt_t fReportedHel    = (fSeedValue & 0x1);
-      UInt_t fEventPolarity  = lbuff[7];
-      UInt_t fReportedQrtHel = lbuff[8];
+      fHelErrorCond   = lbuff[2];
+      fNumEvents      = lbuff[3];
+      fNumPatterns    = lbuff[4];
+      fPatternPhase   = lbuff[5];
+      fSeedValue      = lbuff[6];
+      fPatternHel    = (fSeedValue & 0x1);
+      fEventPolarity  = lbuff[7];
+      fReportedQrtHel = lbuff[8];
       //  lbuff[9] is currently empty.
       /*
 	 std::cout << std::dec << "errorcode=="<<fHelErrorCond
 	 <<"; #event, #pattern=="<<fNumEvents<<", "<<fNumPatterns
 	 <<"; pat_phase=="<<fPatternPhase
-	 <<"; helbit=="<<fReportedHel
+	 <<"; helbit=="<<fPatternHel
 	 <<"; qrthel=="<<std::hex<<fReportedQrtHel<<std::dec
 	 <<"; polarity=="<<fEventPolarity
 	 <<std::endl;
 	 std::cout <<std::dec << "LHRS FADC data: " 
-	 << fadcdata[0] << ", HEL="
-	 << fadcdata[1] << ", QRT="
-	 << fadcdata[2] << ", MPS="
-	 << fadcdata[3] << std::endl;  
+	 << fFADCSpare    << ", HEL="
+	 << fFADCHelicity << ", QRT="
+	 << fFADCPatSync  << ", MPS="
+	 << fFADCTSettle  << std::endl;
 	 std::cout <<std::dec << "SBS FADC data: " 
-	 << fadcdata[4] << ", HEL="
-	 << fadcdata[5] << ", QRT="
-	 << fadcdata[6] << ", MPS="
-	 << fadcdata[7] << std::endl;  
+	 << fFADCSpare_sbs    << ", HEL="
+	 << fFADCHelicity_sbs << ", QRT="
+	 << fFADCPatSync_sbs  << ", MPS="
+	 << fFADCTSettle_sbs  << std::endl;
 	 */
    }
 

--- a/SBSScalerHelicityReader.h
+++ b/SBSScalerHelicityReader.h
@@ -30,6 +30,7 @@ class SBSScalerHelicityReader {
       UInt_t GetTimeStampTir() const { return fTimeStampTir; };
       // in parallel, these signals are recorded in the ring buffer of the helicity gated scaler
       // the maximum depth of this ring is for now 500.
+
       UInt_t GetRingDepth() const { return fIRing; }; // how many events are in the ring
       // I should have the depth of the ring defined in the data base
       // let call it kHelRingDepth for now
@@ -71,11 +72,33 @@ class SBSScalerHelicityReader {
       void Begin();
       void End();
 
+      //  These variables are the reported integrals from the FADCs
+      UInt_t fFADCPatSync;
+      UInt_t fFADCHelicity;
+      UInt_t fFADCTSettle;
+      UInt_t fFADCSpare;
+
+      //  These variables are the reported integrals from the FADCs
+      UInt_t fFADCPatSync_sbs;
+      UInt_t fFADCHelicity_sbs;
+      UInt_t fFADCTSettle_sbs;
+      UInt_t fFADCSpare_sbs;
+
+      UInt_t fFADCLow_min;  ///  The minimum value for FADC "low" helicity bit
+      UInt_t fFADCLow_max;  ///  The maximum value for FADC "low" helicity bit
+      UInt_t fFADCHigh_min; ///  The minimum value for FADC "high" helicity bit
+      UInt_t fFADCHigh_max; ///  The maximum value for FADC "high" helicity bit
+
+      UInt_t fFADCQrtHel;
+
+
+      //  These variables should be removed.
       UInt_t fPatternTir;
       UInt_t fHelicityTir;
       UInt_t fTSettleTir;
       UInt_t fTimeStampTir;
       UInt_t fOldTimeStampTir;
+
       UInt_t fIRing;
       // the ring map is defined in 
       // http://www.jlab.org/~adaq/halog/html/1011_archive/101101100943.html
@@ -85,10 +108,30 @@ class SBSScalerHelicityReader {
       UInt_t fHelicityRing[kHelRingDepth];
       UInt_t fPatternRing[kHelRingDepth];
       UInt_t fTimeStampRing[kHelRingDepth];
+      UInt_t fRingFinalQrtHel;
+      UInt_t fRingFinalEvtNum;
+      UInt_t fRingFinalPatNum;
+      UInt_t fRingFinalSeed;
+      UInt_t fRingPattPhase;
+
+      Long_t fScalerYield[32];
+      Long_t fScalerDiff[32];
+
+
       UInt_t fT3Ring[kHelRingDepth];
       UInt_t fU3Ring[kHelRingDepth];
       UInt_t fT5Ring[kHelRingDepth];
       UInt_t fT10Ring[kHelRingDepth];
+
+      //  New summary variables from the helicity CRL
+      UInt_t fHelErrorCond;   //  Helicity ROC error condition
+      UInt_t fNumEvents;      //  Number of helicity windows
+      UInt_t fNumPatterns;    //  Number of patterns
+      UInt_t fPatternPhase;   //  Current pattern phase
+      UInt_t fSeedValue;      //  Seed value for current pattern
+      UInt_t fPatternHel;     //  Current reported helicity at start of pattern
+      UInt_t fEventPolarity;  //  Polarity of the current event with respect to start of pattern:  0x0==same as pattern polarity, 0x1==reversed polarity
+      UInt_t fReportedQrtHel; //  Current "qrthel" value:  0x10==start of pattern, 0x1==Hel+
 
       // ROC information
       // If a header is zero the index is taken to be from the start of

--- a/SBSScalerHelicityReader.h
+++ b/SBSScalerHelicityReader.h
@@ -108,15 +108,6 @@ class SBSScalerHelicityReader {
       UInt_t fHelicityRing[kHelRingDepth];
       UInt_t fPatternRing[kHelRingDepth];
       UInt_t fTimeStampRing[kHelRingDepth];
-      UInt_t fRingFinalQrtHel;
-      UInt_t fRingFinalEvtNum;
-      UInt_t fRingFinalPatNum;
-      UInt_t fRingFinalSeed;
-      UInt_t fRingPattPhase;
-
-      Long_t fScalerYield[32];
-      Long_t fScalerDiff[32];
-
 
       UInt_t fT3Ring[kHelRingDepth];
       UInt_t fU3Ring[kHelRingDepth];


### PR DESCRIPTION
The true helicity, helicity event and pattern counters, and state of the T_settle signal can now be made available in the standard "T" tree with an appropriate odef file.  There are also some other diagnostic words that can be put in the tree if desired.

An independent "TShel" tree is also created, which is filled for each helicity scaler reading, and scaler asymmetries can be calculated on a pattern-by-pattern basis within this tree.  At the moment, calibrations to turn the raw scaler counts to beam current are not included in the code, but that would be the next step.  At the moment the results are not easily interpretable by the casual viewer, as it is still heavy on diagnostic information.

The current version of the SBSScalerHelicity and SBSScalerHelicityReader classes still contain some depreciated code from prior generations of the scaler helicity analysis.  I will be continuing to cleanup those remnants, but this version ought to work to do the helicity tagging of the triggered events, and can provide information about the charge asymmetry with a bit of post-processing.

We could pull this version now and I could continue to do the cleanup work for a later PR, or wait until this development branch is closer to fully ready.