### PR TITLE
Changes in the Helicity Scaler decoding to reduce "zero helicity" events

### DIFF
--- a/SBSScalerHelicityReader.cxx
+++ b/SBSScalerHelicityReader.cxx
@@ -217,6 +217,8 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
    // Obtain the present data from the event for QWEAK helicity mode.
    const UInt_t *lbuff;
    static UInt_t evt_in_pattern;
+   static Int_t evtnum_offset=0;
+   static Int_t patnum_offset=0;
 
    static const char* here = "SBSScalerHelicityReader::ReadData";
 
@@ -422,42 +424,44 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
       if (fHelErrorCond!=sbs_HelErrorCond) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fHelErrorCond: "
 		  << fHelErrorCond << " " << sbs_HelErrorCond << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01010000;
       }
-      if (fNumEvents!=sbs_NumEvents) {
+      if (fNumEvents!=(sbs_NumEvents-evtnum_offset)) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fNumEvents: "
 		  << fNumEvents << " " << sbs_NumEvents << std::endl;
-	fHelErrorCond |= 0x01000000;
+	evtnum_offset = sbs_NumEvents - fNumEvents;
+	fHelErrorCond |= 0x01020000;
       }
-      if (fNumPatterns!=sbs_NumPatterns) {
+      if (fNumPatterns!=(sbs_NumPatterns-patnum_offset)) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fNumPatterns: "
 		  << fNumPatterns << " " << sbs_NumPatterns << std::endl;
-	fHelErrorCond |= 0x01000000;
+	patnum_offset = sbs_NumPatterns - fNumPatterns;
+	fHelErrorCond |= 0x01040000;
       }
       if (fPatternPhase!=sbs_PatternPhase) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fPatternPhase: "
 		  << fPatternPhase << " " << sbs_PatternPhase << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01080000;
       }
       if (fSeedValue!=sbs_SeedValue) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fSeedValue: "
 		  << fSeedValue << " " << sbs_SeedValue << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01100000;
       }
       if (fPatternHel!=sbs_PatternHel) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fPatternHel: "
 		  << fPatternHel << " " << sbs_PatternHel << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01200000;
       }
       if (fEventPolarity!=sbs_EventPolarity) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fEventPolarity: "
 		  << fEventPolarity << " " << sbs_EventPolarity << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01400000;
       }
       if (fReportedQrtHel!=sbs_ReportedQrtHel) {
 	if(fVerbosity>0) std::cerr << here << " LHRS/SBS Mismatch for fReportedQrtHel: "
 		  << fReportedQrtHel << " " << sbs_ReportedQrtHel << std::endl;
-	fHelErrorCond |= 0x01000000;
+	fHelErrorCond |= 0x01800000;
       }
    }
 

--- a/SBSScalerHelicityReader.cxx
+++ b/SBSScalerHelicityReader.cxx
@@ -469,7 +469,7 @@ Int_t SBSScalerHelicityReader::ReadData( const THaEvData& evdata )
 	       << tsettle<<":"<<tsettle_sbs << std::endl;
      fHelErrorCond |= 0x10000000;
    }
-   if (fHelErrorCond!=16 && tsettle==0 &&  hel!= fPatternHel^fEventPolarity){
+   if (fHelErrorCond!=16 && tsettle==0 &&  hel!=(fPatternHel^fEventPolarity)){
      if(fVerbosity>0) std::cerr << here << " Mismatch between FADC helicity bit and value expected from predictor: "
 	       << hel << " " << "fPatternHel==" << fPatternHel
 	       << " fEventPolarity=="<<fEventPolarity << " "


### PR DESCRIPTION
The first fix is for a typo in the test that the FADC helicity bit agrees with the predicted helicity bit; this can cause occasional spurious "zero helicity" events, but not generally a large number of them at a time.

The second fix is more significant:  the helicity scalers in the LHRS and SBS crates begin accumulating scaler events at the GO transition, and there is a test that the number of scaler events is consistent between the two arms.  However, it is possible for one crate to get enabled just early enough to be able to count an extra event.  This had then caused all events to fail this test for the rest of the run.
The fix is to allow an offset between the two event counters.  If they do not agree with consideration of the offset, that physics event is marked as having a bad helicity state, and a new offset is calculated to be used moving forward.
Testing with runs 5943, 5944, 5945, this recovered valid helicity states for all but the first event.