### PR TITLE
Updates related to SIMC generator

### DIFF
--- a/SBSSimDecoder.cxx
+++ b/SBSSimDecoder.cxx
@@ -148,6 +148,8 @@ Int_t SBSSimDecoder::DefineVariables( THaAnalysisObject::EMode mode )
     {"simc_vx",       "MC vertex x co-ordinate from SIMC gen.",   "fVx_simc"},
     {"simc_vy",       "MC vertex y co-ordinate from SIMC gen.",   "fVy_simc"},
     {"simc_vz",       "MC vertex z co-ordinate from SIMC gen.",   "fVz_simc"},
+    {"simc_veE",      "MC scattered e- energy at vertex from SIMC gen.",   "fVeE_simc"},
+    {"simc_vetheta",  "MC scattered e- theta at vertex from SIMC gen.",   "fVetheta_simc"},
     // ** ^^ **
     {"mc_sigma",   "MC cross section",   "fSigma"},
     {"mc_omega",   "MC phase spece generation",   "fOmega"},
@@ -332,6 +334,8 @@ Int_t SBSSimDecoder::DoLoadEvent(const Int_t* evbuffer )
   fVx_simc = simEvent->Tgmn->simc_vx;
   fVy_simc = simEvent->Tgmn->simc_vy;
   fVz_simc = simEvent->Tgmn->simc_vz;
+  fVeE_simc = simEvent->Tgmn->simc_veE;
+  fVetheta_simc = simEvent->Tgmn->simc_vetheta;
   //g4sbs variables
   fSigma = simEvent->Tgmn->ev_sigma;
   fOmega = simEvent->Tgmn->ev_solang;

--- a/SBSSimDecoder.h
+++ b/SBSSimDecoder.h
@@ -175,6 +175,8 @@ protected:
   Double_t fVx_simc;
   Double_t fVy_simc;
   Double_t fVz_simc;
+  Double_t fVeE_simc;
+  Double_t fVetheta_simc;
   // g4sbs variables
   Double_t fSigma;
   Double_t fOmega;

--- a/gmn_tree_digitized.h
+++ b/gmn_tree_digitized.h
@@ -48,6 +48,8 @@ public :
    Double_t        simc_vx;
    Double_t        simc_vy;
    Double_t        simc_vz;
+   Double_t        simc_veE;
+   Double_t        simc_vetheta;
    Double_t        ev_count;
    Double_t        ev_rate;
    Double_t        ev_solang;
@@ -463,6 +465,8 @@ public :
    TBranch        *b_simc_vx;   //!
    TBranch        *b_simc_vy;   //!
    TBranch        *b_simc_vz;   //!
+   TBranch        *b_simc_veE;   //!
+   TBranch        *b_simc_vetheta;   //!
    TBranch        *b_ev;   //!
    TBranch        *b_Earm_BBGEM_hit_nhits;   //!
    TBranch        *b_Earm_BBGEM_hit_plane;   //!
@@ -1219,6 +1223,8 @@ void gmn_tree_digitized::Init(TTree *tree)
    fChain->SetBranchAddress("simc.vx", &simc_vx, &b_simc_vx);
    fChain->SetBranchAddress("simc.vy", &simc_vy, &b_simc_vy);
    fChain->SetBranchAddress("simc.vz", &simc_vz, &b_simc_vz);
+   fChain->SetBranchAddress("simc.veE", &simc_veE, &b_simc_veE);
+   fChain->SetBranchAddress("simc.vetheta", &simc_vetheta, &b_simc_vetheta);
    fChain->SetBranchAddress("ev", &ev_count, &b_ev);
    fChain->SetBranchAddress("Earm.BBGEM.hit.nhits", &Earm_BBGEM_hit_nhits, &b_Earm_BBGEM_hit_nhits);
    fChain->SetBranchAddress("Earm.BBGEM.hit.plane", &Earm_BBGEM_hit_plane, &b_Earm_BBGEM_hit_plane);


### PR DESCRIPTION
Added a couple of new output variables "simc.veE" and "simc.vetheta" to store scattered e- energy and angle at the vertex, respectively. This will enable us to calculate "true" vertex.