### PR TITLE
modified decoding of V1190 assigning 'kBig' for missing LE/TE hits

### DIFF
--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -1,6 +1,8 @@
 #include "SBSData.h"
 #include "TMath.h"
 #include <iostream>
+#include "DataType.h"
+
 #define SBS_ADC_MODE_SINGLE 0 //< Simple ADC with only integral
 #define SBS_ADC_MODE_MULTI  1 //< FADC 250 mode 7
 
@@ -96,10 +98,18 @@ namespace SBSData {
     hit->TrigTime = 0;
     if( edge == 0 ) { // Leading edge
       hit->le.raw = val;
-      hit->le.val = (val-fTDC.offset)*fTDC.cal;
-    } else {
+        if(val==kBig){
+            hit->le.val = val; //put kBig for both le.raw and le.val if missing hits
+        }else{
+            hit->le.val = (val-fTDC.offset)*fTDC.cal;
+        }
+    } else if(edge == 1) {
       hit->te.raw = val;
-      hit->te.val = (val-fTDC.offset)*fTDC.cal;
+        if(val==kBig){
+            hit->te.val = val; //put kBig for both te.raw and te.val if missing hits
+        }else{
+            hit->te.val = (val-fTDC.offset)*fTDC.cal;
+        }
     }
     if(fEdgeIdx[0] == fEdgeIdx[1]) { // Both leading and trailing edges now found
       hit->ToT.raw = hit->te.raw - hit->le.raw;

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -1179,7 +1179,9 @@ Int_t SBSGenericDetector::DecodeTDC( const THaEvData& evdata,
   
   if(fIsMC)reftime = 1000.0;
   
+    
   Int_t edge = 0;
+    Int_t le_count = 0; Int_t te_count = 0;
   Int_t elemID=blk->GetID();
   for(Int_t ihit = 0; ihit < nhit; ihit++) {
         if(fModeTDC == SBSModeTDC::kTDCSimple) {
@@ -1203,6 +1205,21 @@ Int_t SBSGenericDetector::DecodeTDC( const THaEvData& evdata,
           edge = tdchit[ihit].edge;
       //           std::cout << ihit << " " << evdata.GetData(d->crate, d->slot, chan, ihit) - reftime << " " << edge << std::endl;
           if (edge ==1 && ihit ==0) continue; // skip first hit if trailing edge
+        
+        if(edge ==0){
+            le_count++;
+        }else if(edge ==1){
+            te_count++;
+        }
+        //insert arbitrary large number (50000 or kbig) for missing hit if observed
+        if(le_count > te_count+1){//missing TE
+            blk->TDC()->Process(elemID,kBig, 1.);
+            te_count++;
+        }else if(le_count < te_count){//missing LE
+            blk->TDC()->Process(elemID,kBig, 0.);
+            le_count++;
+        }
+        
           if (fModeTDC != SBSModeTDC::kTDCSimple && edge ==0 && ihit == nhit-1)  continue; // skip last hit if leading edge
           blk->TDC()->Process(elemID,tdchit[ihit].rawtime - reftime, edge);
        }
@@ -1608,7 +1625,7 @@ Int_t SBSGenericDetector::FindGoodHit(SBSElement *blk)
        Int_t HitIndex = -1;
        Double_t GoodTimeCut = blk->TDC()->GetGoodTimeCut();
        for (Int_t ih=0;ih<nhits;ih++) {
-	 if (abs(blk->TDC()->GetData(ih)-GoodTimeCut) < MinDiff) {
+	 if (std::abs(blk->TDC()->GetData(ih)-GoodTimeCut) < MinDiff) { //without std::abs, it doesn't work for kBig
            HitIndex = ih;
 	   MinDiff = abs(blk->TDC()->GetData(ih)-GoodTimeCut);
 	 }


### PR DESCRIPTION
SBSGenericDetector.cxx and SBSData.cxx are modified to insert 'kBig' for missing hits of V1190. Functions: DecodeTDC() and FindGoodHits() are changed in SBSGenericDetector and TDC::Process() in SBSData.