### PR TITLE
Simple variable definition change - no functionality affected

### DIFF
--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -271,8 +271,8 @@ Int_t SBSCalorimeter::DefineVariables( EMode mode )
     // Store every cluster
     RVarDef vars_raw[] = {
       { "clus.e", "Energy of cluster", "fOutclus.e"},
-      { "clus.atimeblk", "ADC time of cluster", "fOutclus.atime"},
-      { "clus.tdctimeblk", "TDC time of cluster", "fOutclus.tdctime"},
+      { "clus.atimeblk", "ADC time of highest energy blk in the cluster", "fOutclus.atime"},
+      { "clus.tdctimeblk", "TDC time of highest energy blk in the cluster", "fOutclus.tdctime"},
       //{ "clus.e_c","Energy calibrated of cluster", "fOutclus.e_c"},
       { "clus.again","ADC gain coeff. of cluster", "fOutclus.again"},
       { "clus.x", "x-position of cluster", "fOutclus.x"},


### PR DESCRIPTION
I changed the definitions of clus.adctimeblk and clus.tdctimeblk after the introduction of the new energy weighted times last month, but forgot to open a PR. Its a 2 line change that should have no effects on functionality, but will help anyone in the future looking to understand the branches by looking at the code.