### PR TITLE
HCal TDC Timewalk machinery

### DIFF
--- a/SBSCalorimeter.h
+++ b/SBSCalorimeter.h
@@ -29,6 +29,7 @@ struct SBSBlockSet {
   Int_t col;
   Int_t id;
   Double_t TDCTime;
+  Double_t TDCTimeTW;
   Double_t ADCTime;
   Bool_t InCluster;
   Bool_t GoodTDC; 
@@ -37,6 +38,7 @@ struct SBSBlockSet {
 struct SBSCalBlocks {
   std::vector<Double_t> e;   //< []
   std::vector<Double_t> TDCTime;   //< [] 
+  std::vector<Double_t> TDCTimeTW;   //< [] 
   std::vector<Double_t> ADCTime;   //< [] 
   std::vector<Int_t> row; //< []
   std::vector<Int_t> col; //< []
@@ -54,6 +56,7 @@ struct SBSCalBlocks {
     row.clear();
     col.clear();
     TDCTime.clear();
+    TDCTimeTW.clear();
     ADCTime.clear();
     GoodTDC.clear();
   }
@@ -64,6 +67,7 @@ struct SBSCalorimeterOutput {
   std::vector<Double_t> again;   //< []
   std::vector<Double_t> atime;   //< []
   std::vector<Double_t> tdctime;   //< []
+  std::vector<Double_t> tdctime_tw;   //< []
   //std::vector<Double_t> e_c;   //< []
   std::vector<Double_t> x;   //< []
   std::vector<Double_t> y;   //< []
@@ -77,6 +81,7 @@ struct SBSCalorimeterOutput {
   std::vector<Double_t> atime_mean;
   std::vector<Double_t> e_goodtdc;
   std::vector<Double_t> tdctime_mean;
+  std::vector<Double_t> tdctime_mean_tw;
   std::vector<Double_t> blk_e_goodtdc;
   std::vector<Int_t> ngoodtdc;
   std::vector<Int_t> rowgoodtdc;
@@ -99,11 +104,13 @@ public:
 
   virtual Int_t SelectBestCluster();
 
+  Double_t TimeWalk(Double_t time, Double_t eblk, Int_t ID);
   // Get information from the main cluster
   Double_t GetE();             //< Main cluster energy
   Double_t GetAgain();         //< Pedestal subtracted ADC integral (pC)
   Double_t GetAtime();         //< Main cluster ADC time of max block
-  Double_t GetTDCtime();         //< Main cluster ADC time of max block
+  Double_t GetTDCtime();         //< Main cluster TDC time of max block
+  Double_t GetTDCtimeTW();         //< Main cluster TW corr TDC time of max block
   /* Double_t GetECorrected();    //< Main cluster corrected energy */
   Double_t GetX();             //< Main cluster energy average x
   Double_t GetY();             //< Main cluster energy average y
@@ -112,6 +119,7 @@ public:
   Double_t GetAtimeMean();
   Double_t GetEGoodTDC();
   Double_t GetTDCtimeMean();
+  Double_t GetTDCtimeMeanTW();
   Double_t GetEBlkGoodTDC();
 
   /* Double_t GetEBlkCorrected(); //< Main cluster corrected energy of max block in cluster */
@@ -185,6 +193,11 @@ protected:
   Double_t   fSlope;     // slope for gain correction
   Double_t   fAccCharge; // accumulated charge
 
+  //walk corrections
+  std::vector<Double_t> fmeantime_offset; //hcal meantime offset
+  std::vector<Double_t> ftw0; //zeroth walk param (tw0*eblk)
+  std::vector<Double_t> ftw1; //1st walk param (tw1/sqrt(eblk))
+  
   // ROOTFile output level
   Int_t fDataOutputLevel;   //  0: default only main cluster info, 1: include also blocks in main cluster, 2: all clusters,  3: all blocks regardless if they are in a cluster or not
 
@@ -229,6 +242,10 @@ inline Double_t SBSCalorimeter::GetTDCtime() {
   return GetVVal(fMainclus.tdctime);
 }
 
+inline Double_t SBSCalorimeter::GetTDCtimeTW() {
+  return GetVVal(fMainclus.tdctime_tw);
+}
+
 /* inline Double_t SBSCalorimeter::GetECorrected() { */
 /*   return GetVVal(fMainclus.e_c); */
 /* } */
@@ -259,6 +276,9 @@ inline Double_t SBSCalorimeter::GetEGoodTDC() {
 
 inline Double_t SBSCalorimeter::GetTDCtimeMean() {
   return GetVVal(fMainclus.tdctime_mean);
+}
+inline Double_t SBSCalorimeter::GetTDCtimeMeanTW() {
+  return GetVVal(fMainclus.tdctime_mean_tw);
 }
 
 inline Double_t SBSCalorimeter::GetEBlkGoodTDC() {

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -56,6 +56,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
     fTDCtimeTW = block->GetTDCtimeTW();
     fTDCtimeMean = block->GetTDCtime();
     fTDCtimeMeanTW = block->GetTDCtimeTW();
+    fEblk_GoodTDC = block->GetE();
     fE_GoodTDC = block->GetE();
     fRowGoodTDC = block->GetRow();
     fColGoodTDC = block->GetCol();

--- a/SBSCalorimeterCluster.cxx
+++ b/SBSCalorimeterCluster.cxx
@@ -31,6 +31,8 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
   fAtimeMean = fAtime;
   
   fTDCtime  = -1000.0; //Assign a default of -1000 ns for TDC time unless we have actual data!
+  fTDCtimeTW  = -1000.0; //Assign a default of -1000 ns for TDC time unless we have actual data!
+    
   fRow  = block->GetRow();
   fCol  = block->GetCol();
   fElemID  = block->GetID();
@@ -39,6 +41,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
   
   fNgoodTDChits = 0;
   fTDCtimeMean = 0.0;
+  fTDCtimeMeanTW = 0.0;
   
   fEblk_GoodTDC = 0.0;
   fE_GoodTDC = 0.0;
@@ -50,8 +53,9 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk, SBSElement* block)
   if( block->HasTDCData() ){
     fNgoodTDChits = 1;
     fTDCtime = block->GetTDCtime();
+    fTDCtimeTW = block->GetTDCtimeTW();
     fTDCtimeMean = block->GetTDCtime();
-    fEblk_GoodTDC = block->GetE();
+    fTDCtimeMeanTW = block->GetTDCtimeTW();
     fE_GoodTDC = block->GetE();
     fRowGoodTDC = block->GetRow();
     fColGoodTDC = block->GetCol();
@@ -75,6 +79,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk)
   fAgain = 0.;
   fAtime = 0;
   fTDCtime = 0;
+  fTDCtimeTW = 0;
   fRow  = -1;
   fCol  = -1;
   fElemID  = -1;
@@ -82,6 +87,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster(Int_t nmaxblk)
   
   fNgoodTDChits = 0;
   fTDCtimeMean = 0.0;
+  fTDCtimeMeanTW = 0.0;
   fAtimeMean = 0.0;
   fEblk_GoodTDC = 0.0;
   fE_GoodTDC = 0.0;
@@ -102,6 +108,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster() {
   fAgain = 0.;
   fAtime = 0;
   fTDCtime = 0;
+  fTDCtimeTW = 0;
   fRow  = -1;
   fCol  = -1;
   fElemID  = -1;
@@ -111,6 +118,7 @@ SBSCalorimeterCluster::SBSCalorimeterCluster() {
   
   fNgoodTDChits = 0;
   fTDCtimeMean = 0.0;
+  fTDCtimeMeanTW = 0.0;
   fAtimeMean = 0.0;
   fEblk_GoodTDC = 0.0;
   fE_GoodTDC = 0.0;
@@ -140,8 +148,6 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
       fEblk = block->GetE();
       fAtime = block->GetAtime();
       fAgain = block->GetAgain();
-      //fTDCtime = block->GetTDCtime();
-      //if( block->HasTDCData() ) fTDCtime = block->GetTDCtime();
       fRow = block->GetRow();
       fCol = block->GetCol();
       fElemID = block->GetID();
@@ -149,9 +155,11 @@ void SBSCalorimeterCluster::AddElement(SBSElement* block) {
 
     if( block->HasTDCData() ){
       fTDCtimeMean = (fTDCtimeMean*fE_GoodTDC + block->GetTDCtime() * block->GetE())/(fE_GoodTDC + block->GetE());
+      fTDCtimeMeanTW = (fTDCtimeMeanTW*fE_GoodTDC + block->GetTDCtimeTW() * block->GetE())/(fE_GoodTDC + block->GetE());
       fE_GoodTDC += block->GetE();
       if( block->GetE() > fEblk_GoodTDC ){
 	fTDCtime = block->GetTDCtime();
+	fTDCtimeTW = block->GetTDCtimeTW();
 	fEblk_GoodTDC = block->GetE();
 	fRowGoodTDC = block->GetRow();
 	fColGoodTDC = block->GetCol();
@@ -178,12 +186,14 @@ void SBSCalorimeterCluster::Clear( Option_t* opt ) {
   fAgain=0.;
   fAtime=0;
   fTDCtime=0;
+  fTDCtimeTW=0;
   fRow=fCol=fElemID-1;
   fMaxElement = 0;
   fElements.clear();
   fNgoodTDChits = 0;
   fAtimeMean = 0.0;
   fTDCtimeMean = 0.0;
+  fTDCtimeMeanTW = 0.0;
   fEblk_GoodTDC = 0.0;
   fE_GoodTDC = 0.0;
   fRowGoodTDC=fColGoodTDC=fElemIDGoodTDC=-1;

--- a/SBSCalorimeterCluster.h
+++ b/SBSCalorimeterCluster.h
@@ -25,6 +25,7 @@ public:
   Double_t GetAgain() const {return fAgain;}
   Double_t GetAtime() const {return fAtime;}
   Double_t GetTDCtime() const {return fTDCtime;}
+  Double_t GetTDCtimeTW() const {return fTDCtimeTW;}
   Double_t GetEblk() const {return fEblk;}
   Int_t   GetMult() const {return fMult;}
   Int_t   GetRow()  const {return fRow; }
@@ -39,6 +40,7 @@ public:
   Double_t GetAtimeMean() const { return fAtimeMean; }
   Double_t GetE_GoodTDC() const { return fE_GoodTDC; }
   Double_t GetTDCtimeMean() const { return fTDCtimeMean; }
+  Double_t GetTDCtimeMeanTW() const { return fTDCtimeMeanTW; }
   Double_t GetEblk_GoodTDC() const { return fEblk_GoodTDC; }
   Int_t GetNgoodTDChits() const { return fNgoodTDChits; }
   Int_t GetRowGoodTDC() const { return fRowGoodTDC; }
@@ -62,6 +64,7 @@ public:
   SBSElement* GetElement(UInt_t i);
   std::vector<SBSElement*>& GetElements() {return fElements;}
 
+  
   Int_t GetSize() const {return fMult;}
 
   void AddElement(SBSElement* block);
@@ -78,9 +81,11 @@ private:
   Double_t fAgain;   // ADC gain coefficient (GeV/pC)
   Double_t fAtime;       // ADC time  of block with highest E
   Double_t fTDCtime;       // TDC time  of block with highest E
+  Double_t fTDCtimeTW;    // Walk corrected TDC time of block with highest E
   Double_t fEblk;    // Energy of block with highest E
   Double_t fAtimeMean; //Energy-weighted mean ADC time of all blocks
   Double_t fTDCtimeMean; //Energy-weighted mean TDC time of all blocks in the cluster with good TDC hits
+  Double_t fTDCtimeMeanTW;    // Energy-weighted mean TDC time of all Walk corrected blocks in the cluster with good TDC hits
   Double_t fEblk_GoodTDC; //Energy of block with highest E subject to the requirement of a good TDC hit;
   Int_t   fRow;     // Row of block with highest E
   Int_t   fCol;     // Row of block with highest E

--- a/SBSElement.cxx
+++ b/SBSElement.cxx
@@ -15,9 +15,10 @@ ClassImp(SBSElement);
 // Constructor for generic Element (no-data)
 SBSElement::SBSElement(Double_t x, Double_t y,
     Double_t z, Int_t row, Int_t col, Int_t layer, Int_t id) :
-  fX(x), fY(y), fZ(z), fE(0), fAgain(0), fAtime(kBig), fTDCtime(kBig), fRow(row), fCol(col), fLayer(layer),
+  fX(x), fY(y), fZ(z), fE(0), fAgain(0), fAtime(kBig), fTDCtime(kBig), fTDCtimeTW(kBig), fRow(row), fCol(col), fLayer(layer),
   fStat(0), fID(id), fADC(nullptr), fTDC(nullptr), fWaveform(nullptr)
 {
+  //fTDCtimeTW = -1000;
   fIsRFtime = false;
   fIsTrigTime = false;
 }
@@ -63,6 +64,7 @@ void SBSElement::Clear( Option_t* opt )
     fWaveform->Clear();
   fAtime = kBig;
   fTDCtime = kBig;
+  fTDCtimeTW = kBig;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/SBSElement.h
+++ b/SBSElement.h
@@ -29,6 +29,7 @@ public:
   Double_t GetAgain()     const { return fAgain; }
   Double_t GetAtime()     const { return fAtime; }
   Double_t GetTDCtime()     const { return fTDCtime; }
+  Double_t GetTDCtimeTW()     const { return fTDCtimeTW; }
   Int_t   GetRow()   const { return fRow; }
   Int_t   GetCol()   const { return fCol; }
   Int_t   GetLayer() const { return fLayer; }
@@ -48,6 +49,7 @@ public:
   void SetAgain(Double_t var)    { fAgain = var; }
   void SetAtime(Double_t var)    { fAtime = var; }
   void SetTDCtime(Double_t var)    { fTDCtime = var; }
+  void SetTDCtimeTW(Double_t var)    { fTDCtimeTW = var; }
   void SetRow(Int_t var)    { fRow = var; }
   void SetCol(Int_t var)    { fCol = var; }
   void SetLayer(Int_t var)  { fLayer = var; }
@@ -82,6 +84,7 @@ protected:
   Double_t fAgain;   ///< ADC gain coefficient (GeV/pC)
   Double_t fAtime;       ///< ADC time of event in this block
   Double_t fTDCtime;       ///< TDC time of event in this block
+  Double_t fTDCtimeTW;       ///< TDC time of event in this block
 
   Int_t   fRow;     ///< Row of the block
   Int_t   fCol;     ///< Column of the block


### PR DESCRIPTION
Fixed the mistake from the previous PR
Implemented HCal TDC timewalk corrections based on tof calibration work over past several months. This does not include internal alignemnt or rf corrections yet as have been done for the hodoscope, but is still an improvement for gen pass2 replays, for now.