### PR TITLE
Hot fix for ADC good

### DIFF
--- a/SBSSimDecoder.cxx
+++ b/SBSSimDecoder.cxx
@@ -1431,7 +1431,11 @@ Int_t SBSSimDecoder::LoadDetector( std::map<Decoder::THaSlotData*,
 	  //adc < 0: store adc in samps vector as 2^13+adc:
 	  samps.push_back((1<<13)+simev->Tgep->Harm_FT_dighit_adc->at(j));
 	}
-	goodsamps.push_back(simev->Tgep->Harm_FT_dighit_adc_good->at(j));
+	if(simev->Tgep->Harm_FT_dighit_adc_good){
+	  goodsamps.push_back(simev->Tgep->Harm_FT_dighit_adc_good->at(j));
+	}else{
+	  goodsamps.push_back(0);
+	}
       }
       
       if(fDebug>3)
@@ -1500,7 +1504,11 @@ Int_t SBSSimDecoder::LoadDetector( std::map<Decoder::THaSlotData*,
 	  //adc < 0: store adc in samps vector as 2^13+adc:
 	  samps.push_back((1<<13)+simev->Tgep->Harm_FPP1_dighit_adc->at(j));
 	}
-	goodsamps.push_back(simev->Tgep->Harm_FPP1_dighit_adc_good->at(j));
+	if(simev->Tgep->Harm_FPP1_dighit_adc_good){
+	  goodsamps.push_back(simev->Tgep->Harm_FPP1_dighit_adc_good->at(j));
+	}else{
+	  goodsamps.push_back(0);
+	}
       }
       
       if(fDebug>3)


### PR DESCRIPTION
Hot fix: reading of "adc_good" info was not safeguarded by checking the existence of the branches, inducing backwards compatibilities i.e. crash of the program for MC samples which did not have the info available. Now, the existence of the branches are checked.
The local containers are filled with the adc info if they exist, and with 0 if they do not.