### PR TITLE
Including search for multiple pulses in calo waveform mode

### DIFF
--- a/SBSCalorimeter.cxx
+++ b/SBSCalorimeter.cxx
@@ -395,14 +395,26 @@ Int_t SBSCalorimeter::MakeGoodBlocks()
 	  fGoodBlocks.gain.push_back(blk->GetAgain());
 	  fGoodBlocks.ADCTime.push_back(ahit.time.val);
 	} else {
-	  SBSData::Waveform *wave = blk->Waveform();
-	  blk->SetE(wave->GetIntegral().val);
-	  //blk->SetAintp(wave->GetIntegral().val / wave->GetGain());
-	  blk->SetAgain(wave->GetGain() / wave->GetTrigCal());
-	  blk->SetAtime(wave->GetTime().val);
-	  fGoodBlocks.e.push_back(wave->GetIntegral().val);
-	  fGoodBlocks.gain.push_back(blk->GetAgain());
-	  fGoodBlocks.ADCTime.push_back(wave->GetTime().val);
+	  if(fEnableMultiPulse){
+	    SBSData::Waveform *wave = blk->Waveform();
+	    Int_t ind_mult = wave->GetGoodHitIndex();
+	    blk->SetE(wave->GetIntegralMulti(ind_mult).val);
+	    //blk->SetAintp(wave->GetIntegral().val / wave->GetGain());
+	    blk->SetAgain(wave->GetGain() / wave->GetTrigCal());
+	    blk->SetAtime(wave->GetTimeMulti(ind_mult).val);
+	    fGoodBlocks.e.push_back(wave->GetIntegralMulti(ind_mult).val);
+	    fGoodBlocks.gain.push_back(blk->GetAgain());
+	    fGoodBlocks.ADCTime.push_back(wave->GetTimeMulti(ind_mult).val);
+	  }else{
+	    SBSData::Waveform *wave = blk->Waveform();
+	    blk->SetE(wave->GetIntegral().val);
+	    //blk->SetAintp(wave->GetIntegral().val / wave->GetGain());
+	    blk->SetAgain(wave->GetGain() / wave->GetTrigCal());
+	    blk->SetAtime(wave->GetTime().val);
+	    fGoodBlocks.e.push_back(wave->GetIntegral().val);
+	    fGoodBlocks.gain.push_back(blk->GetAgain());
+	    fGoodBlocks.ADCTime.push_back(wave->GetTime().val);
+	  }
 	}
 	if (WithTDC() && blk->TDC()->HasData() ) { 
 	  const SBSData::TDCHit &hit = blk->TDC()->GetGoodHit();

--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -206,6 +206,8 @@ namespace SBSData {
 	}
       }
     }
+
+    
     //
     //    std::cout << " Int = " << IntMinBin << " " << IntMaxBin<< " ThresCrossBin =   " << ThresCrossBin << " peak-found " << PeakFound << std::endl ;
     //
@@ -223,6 +225,11 @@ namespace SBSData {
       std::cout << " Threshold = " << fThresVal << " ped = " << fSamples.ped << " element = " << ThresCrossBin << " " << " Vmid = " << VMid << "  sum = " << sum << " max = " << max << " time = " << FineTime << " tcal = " << fSamples.tcal <<  std::endl;
       }
     */
+    /*
+    if(FineTime == 0.0){
+      std::cout << "time 0 at finetime and peakfound is: " << PeakFound << std::endl;
+    }
+    */
     fSamples.pulse.integral.raw = sum;
     fSamples.pulse.integral.val = (sum-sped)*fSamples.cal;
     fSamples.pulse.time.raw = FineTime;
@@ -234,6 +241,139 @@ namespace SBSData {
     fHasData = (vals.size() > 0);
   }
 
+  void Waveform::ProcessMulti(std::vector<Double_t> &vals)
+  {
+    //printf("vals size %d, samples raw size %d\n", vals.size(), fSamples.samples_raw.size());
+    if( vals.size() != fSamples.samples_raw.size()) {
+      // Resize our data vector
+      fSamples.samples_raw.resize(vals.size());
+      fSamples.samples.resize(vals.size());
+      Clear();
+    }
+    //
+    for(size_t i = 0; i < vals.size(); i++ ) {
+      fSamples.samples_raw[i] = vals[i]*fSamples.ChanTomV;
+    }
+    // Determining pedestal in first and last four samples. Will choose the
+    // minimum of the two.
+    Double_t pedsum_fsamps=0, pedsum_lsamps=0;
+    Int_t NPedsum=GetNPedBin(), totTimeSamps=vals.size();
+    
+    NPedsum= TMath::Min(NPedsum,int(vals.size()));
+    // std::cout << " Npedsum = " << NPedsum << " " << GetNPedBin() << std::endl;
+    
+    for(Int_t i = 0; i < NPedsum ; i++ ) {
+      // Computing pedestal using first N samples
+      pedsum_fsamps += fSamples.samples_raw[i];
+      // Computing pedestal using last N samples
+      pedsum_lsamps += fSamples.samples_raw[(totTimeSamps-1)-i];
+    }
+   
+    SetPed( TMath::Min(pedsum_fsamps,pedsum_lsamps)/NPedsum );
+    for(size_t i = 0; i < vals.size(); i++ ) {
+      fSamples.samples[i] = (fSamples.samples_raw[i]-fSamples.ped)*fSamples.cal;
+    }
+    
+    // Look for multiple threshold crossings
+    Double_t ThresVal=GetThres(); // mV
+    UInt_t ThresCrossBin=TMath::Max(NPedsum-1,0);
+    std::vector<UInt_t> ThresCrossBinList;
+    //    std::cout << " ped = " << fSamples.ped << " thres = " << ThresVal << std::endl ;
+    while ( ThresCrossBin < vals.size() ) {
+      //look for threshold crossings
+      if( fSamples.samples_raw[ThresCrossBin] >= fSamples.ped+ThresVal ){
+	//incase first sample is above threshold (is this necessary?)
+	if( ThresCrossBin == 0 ){
+	  ThresCrossBinList.push_back(ThresCrossBin);
+	//otherwise just check that the previous sample was actually below threshold so we dont just add all samples above threshold
+	}else if( fSamples.samples_raw[ThresCrossBin-1] < fSamples.ped+ThresVal ){
+	  ThresCrossBinList.push_back(ThresCrossBin);
+	}
+      }
+      ThresCrossBin++;
+    }
+    //
+ 
+    fSamples.multipulse.resize(ThresCrossBinList.size());
+    
+    //Loop over all threshold crossings
+    for(int ncross = 0; ncross < ThresCrossBinList.size(); ncross++){
+
+      // if threshold crossing found
+      UInt_t NSB = GetNSB();
+      UInt_t NSA = GetNSA();
+      UInt_t FixedThresCrossBin=GetFixThresBin();
+      Double_t FineTime = 0;
+      Double_t max  = 0;
+      Double_t sum = 0;
+      Double_t sped = 0;
+      
+      Bool_t PeakFound= kFALSE;
+      UInt_t PeakBin= 0;
+      UInt_t IntMinBin= 0;
+      UInt_t IntMaxBin= vals.size();
+      
+      if (ThresCrossBinList[ncross] < vals.size()) {
+	IntMinBin= TMath::Max(ThresCrossBinList[ncross]-NSB,IntMinBin);
+	IntMaxBin= TMath::Min(ThresCrossBinList[ncross]+NSA-1,IntMaxBin);
+      } else {
+	IntMinBin = TMath::Max(FixedThresCrossBin-NSB,IntMinBin);
+	IntMaxBin = TMath::Min(FixedThresCrossBin+NSA-1,IntMaxBin);
+      }
+      // convert to pC, assume tcal is in ns, and 50ohm resistance
+      Double_t pC_Conv = fSamples.tcal/50.;
+      
+      for(size_t i =IntMinBin ; i <IntMaxBin ; i++ ) {
+	sped+=fSamples.ped*pC_Conv;
+	sum+=fSamples.samples_raw[i]*pC_Conv;
+	if ( i >= ThresCrossBinList[ncross] && !PeakFound) {
+	  if (fSamples.samples_raw[i] > max) {
+	    max = fSamples.samples_raw[i];
+	  } else {
+	    PeakFound= kTRUE;
+	    PeakBin = i-1;
+	  }
+	}
+      }
+      //
+      //    std::cout << " Int = " << IntMinBin << " " << IntMaxBin<< " ThresCrossBin =   " << ThresCrossBin << " peak-found " << PeakFound << std::endl ;
+      //
+      Double_t VMid = (max+fSamples.ped)/2.;
+      if (PeakFound) {
+	for(size_t i =IntMinBin ; i <PeakBin+1 ; i++ ) {
+	  if (VMid >= fSamples.samples_raw[i]  && VMid < fSamples.samples_raw[i+1]) {
+	    FineTime = i+(VMid-fSamples.samples_raw[i])/(fSamples.samples_raw[i+1]-fSamples.samples_raw[i]);
+	    /*
+	    std::cout << "good finetime" << std::endl;
+	  }else{
+	    std::cout << "Vmid: " << VMid << " ped: " << fSamples.ped << " , fsamp i: " << fSamples.samples_raw[i] << " , fsamp i+1: " << fSamples.samples_raw[i+1] << " ,i is: " << i << std::endl;
+	    */
+	  }
+	}
+      }
+      
+      /*
+	if (ThresCrossBin==vals.size()) {
+	std::cout << " Threshold = " << fThresVal << " ped = " << fSamples.ped << " element = " << ThresCrossBin << " " << " Vmid = " << VMid << "  sum = " << sum << " max = " << max << " time = " << FineTime << " tcal = " << fSamples.tcal <<  std::endl;
+	}
+      
+      if(FineTime == 0.0){
+	std::cout << "time 0 at finetime and peakfound is: " << PeakFound << std::endl;
+      }
+      */
+      fSamples.multipulse[ncross].integral.raw = sum;
+      fSamples.multipulse[ncross].integral.val = (sum-sped)*fSamples.cal;
+      fSamples.multipulse[ncross].time.raw = FineTime;
+      fSamples.multipulse[ncross].time.val = (FineTime)*fSamples.tcal + fSamples.timeoffset;
+      fSamples.multipulse[ncross].amplitude.raw = max;
+      fSamples.multipulse[ncross].amplitude.val = (max-fSamples.ped)*fSamples.acal;
+      if (max==0) fSamples.multipulse[ncross].amplitude.val=max;
+      //
+      //std::cout << "starting new threshold crossing" << std::endl;
+    }
+    fHasData = (vals.size() > 0);
+  }
+  
   void Waveform::Clear()
   {
     for(size_t i = 0; i < fSamples.samples.size(); i++) {

--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -310,26 +310,24 @@ namespace SBSData {
       
       Bool_t PeakFound= kFALSE;
       UInt_t PeakBin= 0;
-      UInt_t IntMinBin= 0;
-      UInt_t IntMaxBin= vals.size();
+      //UInt_t IntMinBin= 0;
+      //UInt_t IntMaxBin= vals.size();
+      UInt_t IntMinBin= TMath::Max(ThresCrossBinList[ncross]-NSB,IntMinBin);
+      UInt_t IntMaxBin= TMath::Min(ThresCrossBinList[ncross]+NSA-1,IntMaxBin);
       
-      if (ThresCrossBinList[ncross] < vals.size()) {
-	IntMinBin= TMath::Max(ThresCrossBinList[ncross]-NSB,IntMinBin);
-	IntMaxBin= TMath::Min(ThresCrossBinList[ncross]+NSA-1,IntMaxBin);
-      } else {
-	IntMinBin = TMath::Max(FixedThresCrossBin-NSB,IntMinBin);
-	IntMaxBin = TMath::Min(FixedThresCrossBin+NSA-1,IntMaxBin);
-      }
+      //no use for FixedThresCrossBin due to this for loop requiring ThresCrossBinList having atleast one element, so IntMin/MaxBin are always defined by comparison of their initial value to the threshold crossing bin -NSB or +NSA for min or max respectively
+      
       // convert to pC, assume tcal is in ns, and 50ohm resistance
       Double_t pC_Conv = fSamples.tcal/50.;
       
       for(size_t i =IntMinBin ; i <IntMaxBin ; i++ ) {
+	if(fSamples.samples_raw[i] < fSamples.ped+ThresVal) break; //truncate integration if pulse drops below thres before going through window of integration to avoid contribution from later pulse
 	sped+=fSamples.ped*pC_Conv;
 	sum+=fSamples.samples_raw[i]*pC_Conv;
 	if ( i >= ThresCrossBinList[ncross] && !PeakFound) {
 	  if (fSamples.samples_raw[i] > max) {
 	    max = fSamples.samples_raw[i];
-	  } else if (fSamples.samples_raw[i+1] < max) { //check not just random dip down
+	  } else { //look for first decreasing sample after threshold crossing
 	    PeakFound= kTRUE;
 	    PeakBin = i-1;
 	  }

--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -310,10 +310,11 @@ namespace SBSData {
       
       Bool_t PeakFound= kFALSE;
       UInt_t PeakBin= 0;
-      //UInt_t IntMinBin= 0;
-      //UInt_t IntMaxBin= vals.size();
-      UInt_t IntMinBin= TMath::Max(ThresCrossBinList[ncross]-NSB,IntMinBin);
-      UInt_t IntMaxBin= TMath::Min(ThresCrossBinList[ncross]+NSA-1,IntMaxBin);
+      UInt_t IntMinBin= 0;
+      UInt_t IntMaxBin= vals.size();
+      
+      IntMinBin= TMath::Max(ThresCrossBinList[ncross]-NSB,IntMinBin);
+      IntMaxBin= TMath::Min(ThresCrossBinList[ncross]+NSA-1,IntMaxBin);
       
       //no use for FixedThresCrossBin due to this for loop requiring ThresCrossBinList having atleast one element, so IntMin/MaxBin are always defined by comparison of their initial value to the threshold crossing bin -NSB or +NSA for min or max respectively
       
@@ -321,7 +322,7 @@ namespace SBSData {
       Double_t pC_Conv = fSamples.tcal/50.;
       
       for(size_t i =IntMinBin ; i <IntMaxBin ; i++ ) {
-	if(fSamples.samples_raw[i] < fSamples.ped+ThresVal) break; //truncate integration if pulse drops below thres before going through window of integration to avoid contribution from later pulse
+	if(PeakFound && fSamples.samples_raw[i] < fSamples.ped+ThresVal) break; //truncate integration if pulse drops below thres before going through window of integration to avoid contribution from later pulse
 	sped+=fSamples.ped*pC_Conv;
 	sum+=fSamples.samples_raw[i]*pC_Conv;
 	if ( i >= ThresCrossBinList[ncross] && !PeakFound) {

--- a/SBSData.cxx
+++ b/SBSData.cxx
@@ -329,7 +329,7 @@ namespace SBSData {
 	if ( i >= ThresCrossBinList[ncross] && !PeakFound) {
 	  if (fSamples.samples_raw[i] > max) {
 	    max = fSamples.samples_raw[i];
-	  } else {
+	  } else if (fSamples.samples_raw[i+1] < max) { //check not just random dip down
 	    PeakFound= kTRUE;
 	    PeakBin = i-1;
 	  }

--- a/SBSData.h
+++ b/SBSData.h
@@ -60,6 +60,7 @@ namespace SBSData {
     std::vector<Double_t> samples_raw; //< Raw samples
     std::vector<Double_t> samples;     //< Calibrated samples
     PulseADCData         pulse;       //< Pulse information
+    std::vector<PulseADCData> multipulse; //<Pulse information if searching for multiple pulses
   };
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -115,7 +116,7 @@ namespace SBSData {
       Double_t GetDataRaw(UInt_t i)      const { return GetHit(i).integral.raw; }
       Double_t GetTimeData(UInt_t i)         const { return GetHit(i).time.val; }
       Double_t GetData(UInt_t i)         const { return GetHit(i).integral.val; }
-     std::vector<PulseADCData> GetAllHits()  const { return  fADC.hits; }
+      std::vector<PulseADCData> GetAllHits()  const { return  fADC.hits; }
 
       // Setters
       void SetPed(Double_t var)  { fADC.ped = var; }
@@ -224,6 +225,18 @@ namespace SBSData {
       SingleData GetTime()      const { return fSamples.pulse.time; }
       SingleData GetAmplitude() const { return fSamples.pulse.amplitude; }
       Double_t GetTimeData()    const { return fSamples.pulse.time.val; }
+      Int_t GetNHits()               { return fSamples.multipulse.size(); }
+      PulseADCData GetHitMulti(UInt_t i)     const { return fSamples.multipulse[i];        }
+      PulseADCData GetGoodHitMulti()   const { return fSamples.multipulse[fSamples.good_hit]; }
+      SingleData GetIntegralMulti(UInt_t i)  const { return GetHitMulti(i).integral;  }
+      SingleData GetTimeMulti(UInt_t i)      const { return GetHitMulti(i).time;      }
+      SingleData GetAmplitudeMulti(UInt_t i) const { return GetHitMulti(i).amplitude; }
+
+      // Some additional helper functions for easy access to the ADC integral
+      Double_t GetDataRawMulti(UInt_t i)      const { return GetHitMulti(i).integral.raw; }
+      Double_t GetTimeDataMulti(UInt_t i)         const { return GetHitMulti(i).time.val; }
+      Double_t GetDataMulti(UInt_t i)         const { return GetHitMulti(i).integral.val; }
+      std::vector<PulseADCData> GetAllHits()  const { return  fSamples.multipulse; }
 
       // Setters
       void SetValTime(Double_t var)  { fSamples.pulse.time.val = var; }
@@ -240,6 +253,10 @@ namespace SBSData {
       // Process data sets raw value, ped-subtracted and calibrated data
       virtual void Process(std::vector<Double_t> &var);
 
+      // Same as Process method, but looks for multiple pulses in the waveform window and fills multipulse vector
+      virtual void ProcessMulti(std::vector<Double_t> &var);
+
+    
       // Do we have samples data for this event?
       Bool_t HasData() const { return fHasData; }
 

--- a/SBSECal.cxx
+++ b/SBSECal.cxx
@@ -22,6 +22,7 @@ SBSECal::SBSECal( const char* name, const char* description,
   // SetModeTDC(SBSModeTDC::kTDCSimple);
   // SetDisableRefTDC(true);
   // fWithLED = true;
+  SetEnableMultiPulse(true);
 
   //Default values for time-based cuts for best cluster selection:
   // fRequireTDCGoodCluster = false;

--- a/SBSECal.cxx
+++ b/SBSECal.cxx
@@ -22,7 +22,7 @@ SBSECal::SBSECal( const char* name, const char* description,
   // SetModeTDC(SBSModeTDC::kTDCSimple);
   // SetDisableRefTDC(true);
   // fWithLED = true;
-  SetEnableMultiPulse(true);
+  SetEnableMultiPulse(false);
 
   //Default values for time-based cuts for best cluster selection:
   // fRequireTDCGoodCluster = false;

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -1116,10 +1116,6 @@ Int_t SBSGenericDetector::DefineVariables( EMode mode )
       ve.push_back({ "Ref.samps_elemID", "Calibrated ADC samples",  "fGood.samps_elemID" });
     }
     
-    if (fEnableMultiPulse){
-      ve.push_back({ "npulses", "Number of pulses above threshold in waveform", "fGood.npulses" });
-    }
-    
   }
 
   ve.push_back({0}); // Needed to specify the end of list
@@ -1873,135 +1869,90 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
 	  }
 	}
       } else { // Waveform mode
-	if(fEnableMultiPulse == true){
-	  SBSData::Waveform *wave = blk->Waveform();
-	  if(wave->HasData()) {
-	    Int_t ind_mult = wave->GetGoodHitIndex();
-	    if(fStoreRawHits) {
-	      std::vector<Double_t> &s_r =wave->GetDataRaw();
-	      std::vector<Double_t> &s_c = wave->GetData();
-	      nsamples = s_r.size();
-	      idx = fGood.samps.size();
-	      fGood.sidx.push_back(idx);
-	      fGood.samps_elemID.push_back(k);
-	      fGood.nsamps.push_back(nsamples);
-	      fGood.samps.resize(idx+nsamples);
-	      for(size_t s = 0; s < nsamples; s++) {
-		fGood.samps[idx+s]   = s_c[s];
-	      }
+	SBSData::Waveform *wave = blk->Waveform();
+	if(wave->HasData()) {
+	  if(fStoreRawHits) {
+	    std::vector<Double_t> &s_r =wave->GetDataRaw();
+	    std::vector<Double_t> &s_c = wave->GetData();
+	    nsamples = s_r.size();
+	    idx = fGood.samps.size();
+	    fGood.sidx.push_back(idx);
+	    fGood.samps_elemID.push_back(k);
+	    fGood.nsamps.push_back(nsamples);
+	    fGood.samps.resize(idx+nsamples);
+	    for(size_t s = 0; s < nsamples; s++) {
+	      fGood.samps[idx+s]   = s_c[s];
 	    }
-	    if (wave->GetGoodHitIndex() >=0) {
-	      fNGoodADChits++;
-	      fGood.ADCrow.push_back(blk->GetRow());
-	      fGood.ADCcol.push_back(blk->GetCol());
-	      fGood.ADClayer.push_back(blk->GetLayer());
-	      fGood.ADCelemID.push_back(blk->GetID());
-	      fGood.ADCxpos.push_back(blk->GetX());
-	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
-	      
-	      //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
-	      
+	  }
+	  if (wave->GetGoodHitIndex() >=0) {
+	    fNGoodADChits++;
+	    fGood.ADCrow.push_back(blk->GetRow());
+	    fGood.ADCcol.push_back(blk->GetCol());
+	    fGood.ADClayer.push_back(blk->GetLayer());
+	    fGood.ADCelemID.push_back(blk->GetID());
+	    fGood.ADCxpos.push_back(blk->GetX());
+	    fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	    
+	    //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
+	    Double_t gain= wave->GetGain();
+	    Double_t again=wave->GetAmpCal();	      
+	    Double_t trigcal=wave->GetTrigCal();
+	    
+	    if(fEnableMultiPulse == true){
+	      Int_t ind_mult = wave->GetGoodHitIndex();
 	      fGood.ped.push_back(wave->GetPed());
-	      fGood.a_mult.push_back(0);
+	      fGood.a_mult.push_back(wave->GetNHits());
 	      if (wave->GetTimeMulti(ind_mult).val>0) fGood.a_mult.push_back(1);
 	      fGood.a.push_back(wave->GetIntegralMulti(ind_mult).raw);
-	      Double_t gain= wave->GetGain();
 	      fGood.a_p.push_back(wave->GetIntegralMulti(ind_mult).val/gain);
 	      fGood.a_c.push_back(wave->GetIntegralMulti(ind_mult).val);
 	      fGood.a_amp.push_back(wave->GetAmplitudeMulti(ind_mult).raw);
-	      Double_t again=wave->GetAmpCal();	      
-	      Double_t trigcal=wave->GetTrigCal();	      
 	      fGood.a_amp_p.push_back(wave->GetAmplitudeMulti(ind_mult).val/again);
 	      fGood.a_amp_c.push_back(wave->GetAmplitudeMulti(ind_mult).val);
 	      fGood.a_amptrig_p.push_back(wave->GetAmplitudeMulti(ind_mult).val/again*trigcal);
 	      fGood.a_amptrig_c.push_back(wave->GetAmplitudeMulti(ind_mult).val*trigcal);
 	      fGood.a_time.push_back(wave->GetTimeMulti(ind_mult).val);
-	      fGood.npulses.push_back(wave->GetNHits());
-
-	    } else if (fStoreEmptyElements) {
-	      fGood.ADCrow.push_back(blk->GetRow());
-	      fGood.ADCcol.push_back(blk->GetCol());
-	      fGood.ADClayer.push_back(blk->GetLayer());
-	      fGood.ADCelemID.push_back(blk->GetID());
-	      fGood.ADCxpos.push_back(blk->GetX());
-	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
-	      fGood.a_mult.push_back(0);
-	      fGood.ped.push_back(wave->GetPed());
-	      fGood.a.push_back(wave->GetIntegralMulti(ind_mult).raw);
-	      Double_t gain= wave->GetGain();
-	      fGood.a_p.push_back(wave->GetIntegralMulti(ind_mult).val/gain);
-	      fGood.a_c.push_back(wave->GetIntegralMulti(ind_mult).val);
-	      fGood.a_amp.push_back(0.0);
-	      fGood.a_amp_p.push_back(0.0);
-	      fGood.a_amp_c.push_back(0.0);
-	      fGood.a_amptrig_p.push_back(0.0);
-	      fGood.a_amptrig_c.push_back(0.0);
-	      fGood.a_time.push_back(0.0);
-	    }
-	  }
-	} else {
-	  SBSData::Waveform *wave = blk->Waveform();
-	  if(wave->HasData()) {
-	    //std::cout << "Hit index: " << wave->GetGoodHitIndex() << std::endl;
-	    if(fStoreRawHits) {
-	      std::vector<Double_t> &s_r =wave->GetDataRaw();
-	      std::vector<Double_t> &s_c = wave->GetData();
-	      nsamples = s_r.size();
-	      idx = fGood.samps.size();
-	      fGood.sidx.push_back(idx);
-	      fGood.samps_elemID.push_back(k);
-	      fGood.nsamps.push_back(nsamples);
-	      fGood.samps.resize(idx+nsamples);
-	      for(size_t s = 0; s < nsamples; s++) {
-		fGood.samps[idx+s]   = s_c[s];
-	      }
-	    }
-	    if (wave->GetGoodHitIndex() >=0) {
-	      fNGoodADChits++;
-	      fGood.ADCrow.push_back(blk->GetRow());
-	      fGood.ADCcol.push_back(blk->GetCol());
-	      fGood.ADClayer.push_back(blk->GetLayer());
-	      fGood.ADCelemID.push_back(blk->GetID());
-	      fGood.ADCxpos.push_back(blk->GetX());
-	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
-	      
-	      //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
-	      
+	    }else{
 	      fGood.ped.push_back(wave->GetPed());
 	      fGood.a_mult.push_back(0);
 	      if (wave->GetTime().val>0) fGood.a_mult.push_back(1);
 	      fGood.a.push_back(wave->GetIntegral().raw);
-	      Double_t gain= wave->GetGain();
 	      fGood.a_p.push_back(wave->GetIntegral().val/gain);
 	      fGood.a_c.push_back(wave->GetIntegral().val);
-	      fGood.a_amp.push_back(wave->GetAmplitude().raw);
-	      Double_t again=wave->GetAmpCal();	      
-	      Double_t trigcal=wave->GetTrigCal();	      
+	      fGood.a_amp.push_back(wave->GetAmplitude().raw);	      
 	      fGood.a_amp_p.push_back(wave->GetAmplitude().val/again);
 	      fGood.a_amp_c.push_back(wave->GetAmplitude().val);
 	      fGood.a_amptrig_p.push_back(wave->GetAmplitude().val/again*trigcal);
 	      fGood.a_amptrig_c.push_back(wave->GetAmplitude().val*trigcal);
 	      fGood.a_time.push_back(wave->GetTime().val);
-	    } else if (fStoreEmptyElements) {
-	      fGood.ADCrow.push_back(blk->GetRow());
-	      fGood.ADCcol.push_back(blk->GetCol());
-	      fGood.ADClayer.push_back(blk->GetLayer());
-	      fGood.ADCelemID.push_back(blk->GetID());
-	      fGood.ADCxpos.push_back(blk->GetX());
-	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
-	      fGood.a_mult.push_back(0);
-	      fGood.ped.push_back(wave->GetPed());
+	    }
+
+	  } else if (fStoreEmptyElements) {
+	    fGood.ADCrow.push_back(blk->GetRow());
+	    fGood.ADCcol.push_back(blk->GetCol());
+	    fGood.ADClayer.push_back(blk->GetLayer());
+	    fGood.ADCelemID.push_back(blk->GetID());
+	    fGood.ADCxpos.push_back(blk->GetX());
+	    fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	    fGood.a_mult.push_back(0);
+	    fGood.ped.push_back(wave->GetPed());
+	    Double_t gain= wave->GetGain();
+	    if(fEnableMultiPulse == true){
+	      Int_t ind_mult = wave->GetGoodHitIndex();
+	      fGood.a.push_back(wave->GetIntegralMulti(ind_mult).raw);
+	      fGood.a_p.push_back(wave->GetIntegralMulti(ind_mult).val/gain);
+	      fGood.a_c.push_back(wave->GetIntegralMulti(ind_mult).val);
+	    }else{
 	      fGood.a.push_back(wave->GetIntegral().raw);
-	      Double_t gain= wave->GetGain();
 	      fGood.a_p.push_back(wave->GetIntegral().val/gain);
 	      fGood.a_c.push_back(wave->GetIntegral().val);
-	      fGood.a_amp.push_back(0.0);
-	      fGood.a_amp_p.push_back(0.0);
-	      fGood.a_amp_c.push_back(0.0);
-	      fGood.a_amptrig_p.push_back(0.0);
-	      fGood.a_amptrig_c.push_back(0.0);
-	      fGood.a_time.push_back(0.0);
 	    }
+	    fGood.a_amp.push_back(0.0);
+	    fGood.a_amp_p.push_back(0.0);
+	    fGood.a_amp_c.push_back(0.0);
+	    fGood.a_amptrig_p.push_back(0.0);
+	    fGood.a_amptrig_c.push_back(0.0);
+	    fGood.a_time.push_back(0.0);
 	  }
 	}
       }
@@ -2054,34 +2005,29 @@ Int_t SBSGenericDetector::FindGoodHit(SBSElement *blk)
 	blk->ADC()->SetGoodHit(HitIndex);
 	GoodHit=1;
       }
-    } else if (fModeADC == SBSModeADC::kWaveform && fEnableMultiPulse == true) {
-      SBSData::Waveform *wave = blk->Waveform();
-      wave->SetGoodHit(-1);
-      if (wave->HasData())  {
-	Int_t nhits = wave->GetNHits(); //returns size of multipulse vector
-	Double_t MinDiff = 10000.;
-	Int_t HitIndex = -1;
-	Double_t GoodTimeCut = wave->GetGoodTimeCut(); //using this from adc for now
-	for (Int_t ih=0; ih<nhits; ih++) {
-	  Double_t PulseTime = wave->GetTimeDataMulti(ih);
-	  Double_t PulseTimeRaw = wave->GetTimeMulti(ih).raw;
-	  //this finds the best timed hit from the pulses in the multipulse vector
-	  //do we want to store multiple of these within a threshold of PulseTime-GoodTimeCut?
-	  //if so need a separate SetGoodHitMulti setter method
-	  if (PulseTimeRaw > 0 && abs(PulseTime-GoodTimeCut) < MinDiff) {
-	    HitIndex = ih;
-	    MinDiff = abs(PulseTime - GoodTimeCut);
-	  }
-	}
-	wave->SetGoodHit(HitIndex);
-	GoodHit=1;
-      }
     } else if (fModeADC == SBSModeADC::kWaveform) {
       SBSData::Waveform *wave = blk->Waveform();
       wave->SetGoodHit(-1);
       if (wave->HasData())  {
 	Int_t HitIndex = -1;
-	if (wave->GetTime().raw > 0 ) HitIndex = 0;
+	if(fEnableMultiPulse == true){
+	  Int_t nhits = wave->GetNHits(); //returns size of multipulse vector
+	  Double_t MinDiff = 10000.;
+	  Double_t GoodTimeCut = wave->GetGoodTimeCut(); //using this from adc for now
+	  for (Int_t ih=0; ih<nhits; ih++) {
+	    Double_t PulseTime = wave->GetTimeDataMulti(ih);
+	    Double_t PulseTimeRaw = wave->GetTimeMulti(ih).raw;
+	    //this finds the best timed hit from the pulses in the multipulse vector
+	    //do we want to store multiple of these within a threshold of PulseTime-GoodTimeCut?
+	    //if so need a separate SetGoodHitMulti setter method
+	    if (PulseTimeRaw > 0 && fabs(PulseTime-GoodTimeCut) < MinDiff) {
+	      HitIndex = ih;
+	      MinDiff = fabs(PulseTime - GoodTimeCut);
+	    }
+	  }
+	}else{
+	  if (wave->GetTime().raw > 0 ) HitIndex = 0;
+	}
 	wave->SetGoodHit(HitIndex);
 	GoodHit=1;
       }

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -2077,10 +2077,11 @@ Int_t SBSGenericDetector::FindGoodHit(SBSElement *blk)
 	Double_t GoodTimeCut = wave->GetGoodTimeCut(); //using this from adc for now
 	for (Int_t ih=0; ih<nhits; ih++) {
 	  Double_t PulseTime = wave->GetTimeDataMulti(ih);
+	  Double_t PulseTimeRaw = wave->GetTimeMulti(ih).raw;
 	  //this finds the best timed hit from the pulses in the multipulse vector
 	  //do we want to store multiple of these within a threshold of PulseTime-GoodTimeCut?
 	  //if so need a separate SetGoodHitMulti setter method
-	  if (PulseTime > 0 && abs(PulseTime-GoodTimeCut) < MinDiff) {
+	  if (PulseTimeRaw > 0 && abs(PulseTime-GoodTimeCut) < MinDiff) {
 	    HitIndex = ih;
 	    MinDiff = abs(PulseTime - GoodTimeCut);
 	  }

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -41,7 +41,7 @@ SBSGenericDetector::SBSGenericDetector( const char* name, const char* descriptio
   fDisableRefADC(true),fDisableRefTDC(true),
   fStoreEmptyElements(false), fIsMC(false), fChanMapStart(0),
   fCoarseProcessed(false), fFineProcessed(false),
-  fConst(1.0), fSlope(0.0), fAccCharge(0.0), fStoreRawHits(false)
+  fConst(1.0), fSlope(0.0), fAccCharge(0.0), fStoreRawHits(false), fEnableMultiPulse(false)
 {
   // Constructor.
   fDecodeRFtime = false;
@@ -1112,6 +1112,11 @@ Int_t SBSGenericDetector::DefineVariables( EMode mode )
       ve.push_back({ "Ref.samps", "Calibrated ADC samples",  "fGood.samps" });
       ve.push_back({ "Ref.samps_elemID", "Calibrated ADC samples",  "fGood.samps_elemID" });
     }
+    /*
+    if (fEnableMultiPulse){
+      ve.push_back({ kip
+    }
+    */
   }
 
   ve.push_back({0}); // Needed to specify the end of list
@@ -1245,10 +1250,19 @@ Int_t SBSGenericDetector::DecodeADC( const THaEvData& evdata,
     for(UInt_t i = 0; i < nhit; i++) {
       samples[i] = evdata.GetData(d->crate, d->slot, chan, i);
     }
-    blk->Waveform()->Process(samples);
+    if(fEnableMultiPulse){
+      blk->Waveform()->ProcessMulti(samples);
+    }else{
+      blk->Waveform()->Process(samples);
+    }
     samples.clear();
     SBSData::Waveform *wave = blk->Waveform();
-    wave->SetValTime(wave->GetTime().val- reftime);
+    if(fEnableMultiPulse){
+      //time.raw and time.val are already set in SBSData.cxx for multipulse in ProcessMulti
+      //wave->SetValTime(wave->GetTimeMulti(wave->GetGoodHitIndex()).val- reftime); //using GetTimeMulti
+    }else{
+      wave->SetValTime(wave->GetTime().val- reftime);
+    }
   }
   return nhit;
 }
@@ -1855,66 +1869,151 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
 	  }
 	}
       } else { // Waveform mode
-        SBSData::Waveform *wave = blk->Waveform();
-	if(wave->HasData()) {		
-          if(fStoreRawHits) {
-	    std::vector<Double_t> &s_r =wave->GetDataRaw();
-	    std::vector<Double_t> &s_c = wave->GetData();
-	    nsamples = s_r.size();
-	    idx = fGood.samps.size();
-	    fGood.sidx.push_back(idx);
-	    fGood.samps_elemID.push_back(k);
-	    fGood.nsamps.push_back(nsamples);
-	    fGood.samps.resize(idx+nsamples);
-	    for(size_t s = 0; s < nsamples; s++) {
-	      fGood.samps[idx+s]   = s_c[s];
-            }
-	  }
-	  if (wave->GetGoodHitIndex() >=0) {
-	    fNGoodADChits++;
-	    fGood.ADCrow.push_back(blk->GetRow());
-	    fGood.ADCcol.push_back(blk->GetCol());
-	    fGood.ADClayer.push_back(blk->GetLayer());
-	    fGood.ADCelemID.push_back(blk->GetID());
-	    fGood.ADCxpos.push_back(blk->GetX());
-	    fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	if(fEnableMultiPulse == true){
+	  SBSData::Waveform *wave = blk->Waveform();
+	  if(wave->HasData()) {
+	    Int_t ind_mult = wave->GetGoodHitIndex();
+	    if(fStoreRawHits) {
+	      std::vector<Double_t> &s_r =wave->GetDataRaw();
+	      std::vector<Double_t> &s_c = wave->GetData();
+	      nsamples = s_r.size();
+	      idx = fGood.samps.size();
+	      fGood.sidx.push_back(idx);
+	      fGood.samps_elemID.push_back(k);
+	      fGood.nsamps.push_back(nsamples);
+	      fGood.samps.resize(idx+nsamples);
+	      for(size_t s = 0; s < nsamples; s++) {
+		fGood.samps[idx+s]   = s_c[s];
+	      }
+	    }
+	    if (wave->GetGoodHitIndex() >=0) {
+	      fNGoodADChits++;
+	      fGood.ADCrow.push_back(blk->GetRow());
+	      fGood.ADCcol.push_back(blk->GetCol());
+	      fGood.ADClayer.push_back(blk->GetLayer());
+	      fGood.ADCelemID.push_back(blk->GetID());
+	      fGood.ADCxpos.push_back(blk->GetX());
+	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	      
+	      //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
+	      
+	      fGood.ped.push_back(wave->GetPed());
+	      fGood.a_mult.push_back(0);
+	      if (wave->GetTimeMulti(ind_mult).val>0) fGood.a_mult.push_back(1);
+	      fGood.a.push_back(wave->GetIntegralMulti(ind_mult).raw);
+	      Double_t gain= wave->GetGain();
+	      fGood.a_p.push_back(wave->GetIntegralMulti(ind_mult).val/gain);
+	      fGood.a_c.push_back(wave->GetIntegralMulti(ind_mult).val);
+	      fGood.a_amp.push_back(wave->GetAmplitudeMulti(ind_mult).raw);
+	      Double_t again=wave->GetAmpCal();	      
+	      Double_t trigcal=wave->GetTrigCal();	      
+	      fGood.a_amp_p.push_back(wave->GetAmplitudeMulti(ind_mult).val/again);
+	      fGood.a_amp_c.push_back(wave->GetAmplitudeMulti(ind_mult).val);
+	      fGood.a_amptrig_p.push_back(wave->GetAmplitudeMulti(ind_mult).val/again*trigcal);
+	      fGood.a_amptrig_c.push_back(wave->GetAmplitudeMulti(ind_mult).val*trigcal);
+	      fGood.a_time.push_back(wave->GetTimeMulti(ind_mult).val);
+	      /*
+	      //kip testing output
+	      if(wave->GetNHits() >= 2 ){
+		//std::cout << "blk id: " <<  blk->GetID() << std::endl;
+		std::cout << "samp_indx: " << idx/62 << " up to " << (idx+nsamples)/62 << std::endl;
+		std::cout << "chosen best pulse: " << ind_mult << std::endl;
+		std::cout << "number of pulses found: " << wave->GetNHits() << std::endl;
 
-	    //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
-	 
-	    fGood.ped.push_back(wave->GetPed());
-	    fGood.a_mult.push_back(0);
-	    if (wave->GetTime().val>0) fGood.a_mult.push_back(1);
-	    fGood.a.push_back(wave->GetIntegral().raw);
-	    Double_t gain= wave->GetGain();
-	    fGood.a_p.push_back(wave->GetIntegral().val/gain);
-	    fGood.a_c.push_back(wave->GetIntegral().val);
-	    fGood.a_amp.push_back(wave->GetAmplitude().raw);
-	    Double_t again=wave->GetAmpCal();	      
-	    Double_t trigcal=wave->GetTrigCal();	      
-	    fGood.a_amp_p.push_back(wave->GetAmplitude().val/again);
-	    fGood.a_amp_c.push_back(wave->GetAmplitude().val);
-	    fGood.a_amptrig_p.push_back(wave->GetAmplitude().val/again*trigcal);
-	    fGood.a_amptrig_c.push_back(wave->GetAmplitude().val*trigcal);
-	    fGood.a_time.push_back(wave->GetTime().val);
-	  } else if (fStoreEmptyElements) {
-	    fGood.ADCrow.push_back(blk->GetRow());
-	    fGood.ADCcol.push_back(blk->GetCol());
-	    fGood.ADClayer.push_back(blk->GetLayer());
-	    fGood.ADCelemID.push_back(blk->GetID());
-	    fGood.ADCxpos.push_back(blk->GetX());
-	    fGood.ADCypos.push_back(blk->GetY());	  	  	    
-	    fGood.a_mult.push_back(0);
-	    fGood.ped.push_back(wave->GetPed());
-	    fGood.a.push_back(wave->GetIntegral().raw);
-	    Double_t gain= wave->GetGain();
-	    fGood.a_p.push_back(wave->GetIntegral().val/gain);
-	    fGood.a_c.push_back(wave->GetIntegral().val);
-            fGood.a_amp.push_back(0.0);
-            fGood.a_amp_p.push_back(0.0);
-            fGood.a_amp_c.push_back(0.0);
-            fGood.a_amptrig_p.push_back(0.0);
-            fGood.a_amptrig_c.push_back(0.0);
-            fGood.a_time.push_back(0.0);
+		for(int xx = 0; xx < wave->GetNHits(); xx++){
+		  std::cout << "  pulse " << xx << std::endl;
+		  std::cout << "time : " << wave->GetTimeMulti(xx).val << std::endl;
+		  std::cout << "a_amp_p :" << wave->GetAmplitudeMulti(xx).val << std::endl;
+		}
+		std::cout << std::endl;
+
+		
+	      }
+	      */
+	    } else if (fStoreEmptyElements) {
+	      fGood.ADCrow.push_back(blk->GetRow());
+	      fGood.ADCcol.push_back(blk->GetCol());
+	      fGood.ADClayer.push_back(blk->GetLayer());
+	      fGood.ADCelemID.push_back(blk->GetID());
+	      fGood.ADCxpos.push_back(blk->GetX());
+	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	      fGood.a_mult.push_back(0);
+	      fGood.ped.push_back(wave->GetPed());
+	      fGood.a.push_back(wave->GetIntegralMulti(ind_mult).raw);
+	      Double_t gain= wave->GetGain();
+	      fGood.a_p.push_back(wave->GetIntegralMulti(ind_mult).val/gain);
+	      fGood.a_c.push_back(wave->GetIntegralMulti(ind_mult).val);
+	      fGood.a_amp.push_back(0.0);
+	      fGood.a_amp_p.push_back(0.0);
+	      fGood.a_amp_c.push_back(0.0);
+	      fGood.a_amptrig_p.push_back(0.0);
+	      fGood.a_amptrig_c.push_back(0.0);
+	      fGood.a_time.push_back(0.0);
+	    }
+	  }
+	} else {
+	  SBSData::Waveform *wave = blk->Waveform();
+	  if(wave->HasData()) {
+	    //std::cout << "Hit index: " << wave->GetGoodHitIndex() << std::endl;
+	    if(fStoreRawHits) {
+	      std::vector<Double_t> &s_r =wave->GetDataRaw();
+	      std::vector<Double_t> &s_c = wave->GetData();
+	      nsamples = s_r.size();
+	      idx = fGood.samps.size();
+	      fGood.sidx.push_back(idx);
+	      fGood.samps_elemID.push_back(k);
+	      fGood.nsamps.push_back(nsamples);
+	      fGood.samps.resize(idx+nsamples);
+	      for(size_t s = 0; s < nsamples; s++) {
+		fGood.samps[idx+s]   = s_c[s];
+	      }
+	    }
+	    if (wave->GetGoodHitIndex() >=0) {
+	      fNGoodADChits++;
+	      fGood.ADCrow.push_back(blk->GetRow());
+	      fGood.ADCcol.push_back(blk->GetCol());
+	      fGood.ADClayer.push_back(blk->GetLayer());
+	      fGood.ADCelemID.push_back(blk->GetID());
+	      fGood.ADCxpos.push_back(blk->GetX());
+	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	      
+	      //std::cout << "SBSCalorimeter, " << GetName() << " " << blk->GetID() << " " << blk->GetRow() << " " << blk->GetCol() << " " << blk->GetX() << " " << blk->GetY() << std::endl;
+	      
+	      fGood.ped.push_back(wave->GetPed());
+	      fGood.a_mult.push_back(0);
+	      if (wave->GetTime().val>0) fGood.a_mult.push_back(1);
+	      fGood.a.push_back(wave->GetIntegral().raw);
+	      Double_t gain= wave->GetGain();
+	      fGood.a_p.push_back(wave->GetIntegral().val/gain);
+	      fGood.a_c.push_back(wave->GetIntegral().val);
+	      fGood.a_amp.push_back(wave->GetAmplitude().raw);
+	      Double_t again=wave->GetAmpCal();	      
+	      Double_t trigcal=wave->GetTrigCal();	      
+	      fGood.a_amp_p.push_back(wave->GetAmplitude().val/again);
+	      fGood.a_amp_c.push_back(wave->GetAmplitude().val);
+	      fGood.a_amptrig_p.push_back(wave->GetAmplitude().val/again*trigcal);
+	      fGood.a_amptrig_c.push_back(wave->GetAmplitude().val*trigcal);
+	      fGood.a_time.push_back(wave->GetTime().val);
+	    } else if (fStoreEmptyElements) {
+	      fGood.ADCrow.push_back(blk->GetRow());
+	      fGood.ADCcol.push_back(blk->GetCol());
+	      fGood.ADClayer.push_back(blk->GetLayer());
+	      fGood.ADCelemID.push_back(blk->GetID());
+	      fGood.ADCxpos.push_back(blk->GetX());
+	      fGood.ADCypos.push_back(blk->GetY());	  	  	    
+	      fGood.a_mult.push_back(0);
+	      fGood.ped.push_back(wave->GetPed());
+	      fGood.a.push_back(wave->GetIntegral().raw);
+	      Double_t gain= wave->GetGain();
+	      fGood.a_p.push_back(wave->GetIntegral().val/gain);
+	      fGood.a_c.push_back(wave->GetIntegral().val);
+	      fGood.a_amp.push_back(0.0);
+	      fGood.a_amp_p.push_back(0.0);
+	      fGood.a_amp_c.push_back(0.0);
+	      fGood.a_amptrig_p.push_back(0.0);
+	      fGood.a_amptrig_c.push_back(0.0);
+	      fGood.a_time.push_back(0.0);
+	    }
 	  }
 	}
       }
@@ -1967,7 +2066,27 @@ Int_t SBSGenericDetector::FindGoodHit(SBSElement *blk)
 	blk->ADC()->SetGoodHit(HitIndex);
 	GoodHit=1;
       }
-
+    } else if (fModeADC == SBSModeADC::kWaveform && fEnableMultiPulse == true) {
+      SBSData::Waveform *wave = blk->Waveform();
+      wave->SetGoodHit(-1);
+      if (wave->HasData())  {
+	Int_t nhits = wave->GetNHits(); //returns size of multipulse vector
+	Double_t MinDiff = 10000.;
+	Int_t HitIndex = -1;
+	Double_t GoodTimeCut = wave->GetGoodTimeCut(); //using this from adc for now
+	for (Int_t ih=0; ih<nhits; ih++) {
+	  Double_t PulseTime = wave->GetTimeDataMulti(ih);
+	  //this finds the best timed hit from the pulses in the multipulse vector
+	  //do we want to store multiple of these within a threshold of PulseTime-GoodTimeCut?
+	  //if so need a separate SetGoodHitMulti setter method
+	  if (PulseTime > 0 && abs(PulseTime-GoodTimeCut) < MinDiff) {
+	    HitIndex = ih;
+	    MinDiff = abs(PulseTime - GoodTimeCut);
+	  }
+	}
+	wave->SetGoodHit(HitIndex);
+	GoodHit=1;
+      }
     } else if (fModeADC == SBSModeADC::kWaveform) {
       SBSData::Waveform *wave = blk->Waveform();
       wave->SetGoodHit(-1);

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -2020,7 +2020,7 @@ Int_t SBSGenericDetector::FindGoodHit(SBSElement *blk)
 	    //this finds the best timed hit from the pulses in the multipulse vector
 	    //do we want to store multiple of these within a threshold of PulseTime-GoodTimeCut?
 	    //if so need a separate SetGoodHitMulti setter method
-	    if (PulseTimeRaw > 0 && fabs(PulseTime-GoodTimeCut) < MinDiff) {
+	      if (PulseTimeRaw > 0 && std::fabs(PulseTime-GoodTimeCut) < MinDiff) {
 	      HitIndex = ih;
 	      MinDiff = fabs(PulseTime - GoodTimeCut);
 	    }

--- a/SBSGenericDetector.cxx
+++ b/SBSGenericDetector.cxx
@@ -1112,11 +1112,11 @@ Int_t SBSGenericDetector::DefineVariables( EMode mode )
       ve.push_back({ "Ref.samps", "Calibrated ADC samples",  "fGood.samps" });
       ve.push_back({ "Ref.samps_elemID", "Calibrated ADC samples",  "fGood.samps_elemID" });
     }
-    /*
+    
     if (fEnableMultiPulse){
-      ve.push_back({ kip
+      ve.push_back({ "npulses", "Number of pulses above threshold in waveform", "fGood.npulses" });
     }
-    */
+    
   }
 
   ve.push_back({0}); // Needed to specify the end of list
@@ -1912,6 +1912,7 @@ Int_t SBSGenericDetector::CoarseProcess(TClonesArray& )// tracks)
 	      fGood.a_amptrig_p.push_back(wave->GetAmplitudeMulti(ind_mult).val/again*trigcal);
 	      fGood.a_amptrig_c.push_back(wave->GetAmplitudeMulti(ind_mult).val*trigcal);
 	      fGood.a_time.push_back(wave->GetTimeMulti(ind_mult).val);
+	      fGood.npulses.push_back(wave->GetNHits());
 	      /*
 	      //kip testing output
 	      if(wave->GetNHits() >= 2 ){

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -140,6 +140,7 @@ public:
   void SetDisableRefTDC(Bool_t b) { fDisableRefTDC = b; }
   void SetStoreRawHits(Bool_t var) { fStoreRawHits = var; }
   void SetStoreEmptyElements(Bool_t b) { fStoreEmptyElements = b; }
+  void SetEnableMultiPulse(Bool_t b) { fEnableMultiPulse = b; }
 
   Bool_t WithTDC() { return fModeTDC != SBSModeTDC::kNone; };
   Bool_t WithADC() { return fModeADC != SBSModeADC::kNone; };
@@ -198,6 +199,7 @@ protected:
   Bool_t fIsMC; // flag to indicate if data are simulated;
   Int_t fF1_RollOver;
   Int_t fF1_TimeWindow;
+  Bool_t fEnableMultiPulse;
   
   // Mapping (see also fDetMap)
   UShort_t   fChanMapStart; ///< Starting number for element number (i.e. 0 or 1)
@@ -209,6 +211,7 @@ protected:
 
   // Output variable containers
   SBSGenericOutputData fGood;     //< Good data output
+  SBSGenericOutputData fGoodMulti;     //< Good data output from multipulse
   SBSGenericOutputData fRaw;      //< All hits
   SBSGenericOutputData fRefGood;     //< Good Ref time data output
   SBSGenericOutputData fRefRaw;      //< All Ref time hits

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -89,6 +89,7 @@ struct SBSGenericOutputData {
   std::vector<Int_t> nsamps;      //< [] Number of ADC samples
   std::vector<Int_t> sidx;        //< [] Index of start of ADC samples in for this row-col-layer
   std::vector<Double_t> samps;     //< []*nsamps ADC samples
+  std::vector<Int_t> npulses;     //< []*number of pulses in waveform
 
   // Quick clear class
   void clear() {

--- a/SBSGenericDetector.h
+++ b/SBSGenericDetector.h
@@ -90,7 +90,6 @@ struct SBSGenericOutputData {
   std::vector<Int_t> nsamps;      //< [] Number of ADC samples
   std::vector<Int_t> sidx;        //< [] Index of start of ADC samples in for this row-col-layer
   std::vector<Double_t> samps;     //< []*nsamps ADC samples
-  std::vector<Int_t> npulses;     //< []*number of pulses in waveform
 
   // Quick clear class
   void clear() {
@@ -214,7 +213,6 @@ protected:
 
   // Output variable containers
   SBSGenericOutputData fGood;     //< Good data output
-  SBSGenericOutputData fGoodMulti;     //< Good data output from multipulse
   SBSGenericOutputData fRaw;      //< All hits
   SBSGenericOutputData fRefGood;     //< Good Ref time data output
   SBSGenericOutputData fRefRaw;      //< All Ref time hits

--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -21,6 +21,7 @@ SBSHCal::SBSHCal( const char* name, const char* description,
   SetModeTDC(SBSModeTDC::kTDCSimple);
   SetDisableRefTDC(true);
   fWithLED = true;
+  SetEnableMultiPulse(true);
 
   //Default values for time-based cuts for best cluster selection:
   fRequireTDCGoodCluster = false;

--- a/SBSHCal.cxx
+++ b/SBSHCal.cxx
@@ -21,7 +21,7 @@ SBSHCal::SBSHCal( const char* name, const char* description,
   SetModeTDC(SBSModeTDC::kTDCSimple);
   SetDisableRefTDC(true);
   fWithLED = true;
-  SetEnableMultiPulse(true);
+  SetEnableMultiPulse(false);
 
   //Default values for time-based cuts for best cluster selection:
   fRequireTDCGoodCluster = false;


### PR DESCRIPTION
Enablemultipulse option is defaulted to false for everything here, but when set to true (preferably in a replay script) the entire waveform window is searched for all threshold crossings and the pulse with best timing based on goodtimecut is chosen as the good pulse. This is just beginning attempt to make basic improvements to the calo pulse finding.